### PR TITLE
fix: locate Steam through the registry, not a fixed probe list

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ import {
   readdirSync,
 } from 'node:fs';
 import { join, resolve, normalize, basename } from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 /** Steam appid for Wallpaper Engine. */
 const WE_APPID = '431960';
@@ -45,6 +46,27 @@ const STEAM_PROBE_DIRS = [
   'D:\\SteamLibrary',
   'E:\\SteamLibrary',
 ];
+
+/** Steam root recorded by the Windows installer; the probe list misses custom dirs. */
+function steamPathFromRegistry() {
+  if (process.platform !== 'win32') return null;
+  try {
+    const reg = join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'reg.exe');
+    const out = execFileSync(
+      reg,
+      ['query', 'HKCU\\Software\\Valve\\Steam', '/v', 'SteamPath'],
+      { encoding: 'utf8', windowsHide: true, timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    const m = /SteamPath\s+REG_SZ\s+(.+)/i.exec(out);
+    return m ? normalize(m[1].trim()) : null;
+  } catch { return null; }
+}
+
+/** Probe list with the registered Steam root first, when it is known. */
+function steamProbeDirs() {
+  const reg = steamPathFromRegistry();
+  return reg ? [reg, ...STEAM_PROBE_DIRS] : STEAM_PROBE_DIRS;
+}
 
 /** Valve KeyValues parser for libraryfolders.vdf: libraries owning WE. */
 function librariesFromVdf(vdfPath) {
@@ -63,11 +85,12 @@ function librariesFromVdf(vdfPath) {
 function locateWallpaperEngine() {
   const candidates = [];
   const libraries = [];
-  for (const probe of STEAM_PROBE_DIRS) {
+  const probes = steamProbeDirs();
+  for (const probe of probes) {
     const vdf = join(probe, 'steamapps', 'libraryfolders.vdf');
     if (existsSync(vdf)) { try { libraries.push(...librariesFromVdf(vdf)); } catch { /* skip */ } }
   }
-  const roots = [...STEAM_PROBE_DIRS, ...libraries];
+  const roots = [...probes, ...libraries];
   for (const root of roots) candidates.push(join(root, 'steamapps', 'common', 'wallpaper_engine'));
   candidates.push('C:\\Program Files (x86)\\Wallpaper Engine');
 
@@ -84,7 +107,7 @@ function locateWallpaperEngine() {
 /** Libraries that own Wallpaper Engine (for the workshop content root). */
 function owningLibraries() {
   const libs = [];
-  for (const probe of STEAM_PROBE_DIRS) {
+  for (const probe of steamProbeDirs()) {
     const vdf = join(probe, 'steamapps', 'libraryfolders.vdf');
     if (existsSync(vdf)) { try { libs.push(...librariesFromVdf(vdf)); } catch { /* skip */ } }
   }


### PR DESCRIPTION
# fix: locate Steam through the registry, not a fixed probe list

## The problem

On a machine with Steam installed to a custom directory, the plugin lists nothing at all:

```json
{"installDir":null,"total":0,"portableCount":0,"wallpapers":[]}
```

The settings row just shows an empty picker. No error, no hint about what went wrong.

`locateWallpaperEngine()` and `owningLibraries()` both look for `libraryfolders.vdf`, but only under five hardcoded roots:

```js
const STEAM_PROBE_DIRS = [
  'C:\\Program Files (x86)\\Steam',
  'C:\\Program Files\\Steam',
  'D:\\Steam',
  'D:\\SteamLibrary',
  'E:\\SteamLibrary',
];
```

My Steam lives at `D:\Games`, which matches none of them, so neither helper finds anything and the inventory comes back empty.

The README says:

> 通过读取 Steam 的 `libraryfolders.vdf` 定位 Wallpaper Engine 安装位置（所以 Steam 装在非默认盘也能用）

That holds only when the *main* Steam install sits in one of the five locations and the extra *libraries* are elsewhere. `libraryfolders.vdf` lives inside the Steam install, so reading it presupposes having already found Steam — probing a fixed list can never cover a relocated install.

## The fix

Steam records its real root in the registry:

```
HKCU\Software\Valve\Steam  →  SteamPath
```

Query that first and prepend the result to the probe list. The five hardcoded roots stay as a fallback for when the key is absent.

`reg.exe` is invoked through an absolute `%SystemRoot%` path rather than by bare name, so the lookup still works on a machine whose `PATH` is missing `System32` (which is how I found this — `execFileSync('reg', …)` failed with `ENOENT`). It also avoids resolving `reg` through a caller-controlled `PATH`.

Non-Windows returns `null` immediately, so nothing changes on other platforms.

## Verification

Windows 11, Steam at `D:\Games`, Wallpaper Engine at `D:\Games\steamapps\common\wallpaper_engine`, against a from-source build of `deepseek-harness` 0.1.0-rc.5.

Before:

```json
{"installDir":null,"total":0,"portableCount":0,"wallpapers":[]}
```

After:

```
installDir   : d:\games\steamapps\common\wallpaper_engine
total        : 45
portableCount: 10
by type      : {'scene': 35, 'video': 7, 'web': 3}
```

Both sources are picked up — 26 from `steamapps/workshop/content/431960` and 19 from the install's own `projects/defaultprojects`. All 45 resolve a preview; the 10 video/web entries stream and play.

Also re-checked with the registry key removed from the equation (forcing the fallback path) to confirm the hardcoded list still behaves as it did before.
