### PR TITLE
fix: drive glass transparency from design tokens, not build-hash classes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -378,27 +378,33 @@ window.__ModuleLoader__.load({
 		         wallpaper colour melts into a soft glow instead of a gray smear;
 		       - a light, low-alpha base (not a dark one) so the wallpaper shows through;
 		       - a 1px top highlight (refraction edge) + soft shadow for "thick glass";
-		       - blur radius + saturation both scale off --we-blur / --we-saturate. */
-		  body[data-we-wallpaper] .uV2eYG_card,
-		  body[data-we-wallpaper] .gdEzaW_bubble {
+		       - blur radius + saturation both scale off --we-blur / --we-saturate.
+
+		     Transparency is driven through the design tokens the surfaces already read
+		     (--dsw-specific-input-major on the composer card, --dsw-specific-bubble on
+		     message bubbles) rather than through class selectors: CSS-module class
+		     names are build hashes and change whenever the shell frontend is rebuilt,
+		     which silently kills the effect. backdrop-filter cannot be expressed as a
+		     token, so the blur itself still needs an element selector — [data-composer-card]
+		     is authored in the shell source and survives rebuilds. Bubbles carry no such
+		     attribute, so they fall back to the module-CSS suffix convention; if that
+		     ever stops matching the bubble stays translucent, just without the blur. */
+		  body[data-we-wallpaper] {
+		    --dsw-specific-input-major: rgba(255, 255, 255, 0.18);
+		    --dsw-specific-bubble: rgba(255, 255, 255, 0.14);
+		  }
+		  body[data-ds-dark-theme][data-we-wallpaper] {
+		    --dsw-specific-input-major: rgba(255, 255, 255, 0.07);
+		    --dsw-specific-bubble: rgba(255, 255, 255, 0.06);
+		  }
+		  body[data-we-wallpaper] [data-composer-card],
+		  body[data-we-wallpaper] [class*="_bubble"] {
 		    -webkit-backdrop-filter: blur(var(--we-blur, 24px)) saturate(var(--we-saturate, 1.8)) brightness(1.08);
 		    backdrop-filter: blur(var(--we-blur, 24px)) saturate(var(--we-saturate, 1.8)) brightness(1.08);
 		    box-shadow:
 		      inset 0 1px 0 rgba(255, 255, 255, var(--we-glass-highlight, 0.3)),
 		      inset 0 -1px 0 rgba(255, 255, 255, 0.05),
 		      0 8px 32px rgba(0, 0, 0, var(--we-glass-shadow, 0.14));
-		  }
-		  body[data-we-wallpaper] .uV2eYG_card {
-		    background: rgba(255, 255, 255, 0.18);
-		  }
-		  body[data-ds-dark-theme][data-we-wallpaper] .uV2eYG_card {
-		    background: rgba(255, 255, 255, 0.07);
-		  }
-		  body[data-we-wallpaper] .gdEzaW_bubble {
-		    background: rgba(255, 255, 255, 0.14);
-		  }
-		  body[data-ds-dark-theme][data-we-wallpaper] .gdEzaW_bubble {
-		    background: rgba(255, 255, 255, 0.06);
 		  }
 
 		  /* Picker chrome. */

--- a/src/client.js
+++ b/src/client.js
@@ -394,27 +394,33 @@ const CSS = `
          wallpaper colour melts into a soft glow instead of a gray smear;
        - a light, low-alpha base (not a dark one) so the wallpaper shows through;
        - a 1px top highlight (refraction edge) + soft shadow for "thick glass";
-       - blur radius + saturation both scale off --we-blur / --we-saturate. */
-  body[data-we-wallpaper] .uV2eYG_card,
-  body[data-we-wallpaper] .gdEzaW_bubble {
+       - blur radius + saturation both scale off --we-blur / --we-saturate.
+
+     Transparency is driven through the design tokens the surfaces already read
+     (--dsw-specific-input-major on the composer card, --dsw-specific-bubble on
+     message bubbles) rather than through class selectors: CSS-module class
+     names are build hashes and change whenever the shell frontend is rebuilt,
+     which silently kills the effect. backdrop-filter cannot be expressed as a
+     token, so the blur itself still needs an element selector — [data-composer-card]
+     is authored in the shell source and survives rebuilds. Bubbles carry no such
+     attribute, so they fall back to the module-CSS suffix convention; if that
+     ever stops matching the bubble stays translucent, just without the blur. */
+  body[data-we-wallpaper] {
+    --dsw-specific-input-major: rgba(255, 255, 255, 0.18);
+    --dsw-specific-bubble: rgba(255, 255, 255, 0.14);
+  }
+  body[data-ds-dark-theme][data-we-wallpaper] {
+    --dsw-specific-input-major: rgba(255, 255, 255, 0.07);
+    --dsw-specific-bubble: rgba(255, 255, 255, 0.06);
+  }
+  body[data-we-wallpaper] [data-composer-card],
+  body[data-we-wallpaper] [class*="_bubble"] {
     -webkit-backdrop-filter: blur(var(--we-blur, 24px)) saturate(var(--we-saturate, 1.8)) brightness(1.08);
     backdrop-filter: blur(var(--we-blur, 24px)) saturate(var(--we-saturate, 1.8)) brightness(1.08);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, var(--we-glass-highlight, 0.3)),
       inset 0 -1px 0 rgba(255, 255, 255, 0.05),
       0 8px 32px rgba(0, 0, 0, var(--we-glass-shadow, 0.14));
-  }
-  body[data-we-wallpaper] .uV2eYG_card {
-    background: rgba(255, 255, 255, 0.18);
-  }
-  body[data-ds-dark-theme][data-we-wallpaper] .uV2eYG_card {
-    background: rgba(255, 255, 255, 0.07);
-  }
-  body[data-we-wallpaper] .gdEzaW_bubble {
-    background: rgba(255, 255, 255, 0.14);
-  }
-  body[data-ds-dark-theme][data-we-wallpaper] .gdEzaW_bubble {
-    background: rgba(255, 255, 255, 0.06);
   }
 
   /* Picker chrome. */


### PR DESCRIPTION
# fix: drive glass transparency from design tokens, not build-hash classes

## The problem

The 玻璃 slider does nothing on any DSH build other than the one the CSS was written against. The slider moves, `--we-blur` updates on `document.body`, and the composer and message bubbles stay completely opaque. There is no console error and nothing visibly wrong — it just silently has no effect.

The liquid-glass rules are keyed on two CSS-module class names:

```css
body[data-we-wallpaper] .uV2eYG_card,
body[data-we-wallpaper] .gdEzaW_bubble { … }
```

`uV2eYG` and `gdEzaW` are build hashes. They are regenerated whenever the DSH frontend is rebuilt, so they only match the specific build they were copied from.

On a from-source build of `deepseek-harness` 0.1.0-rc.5 I fetched all 36 client bundles the shell boots and grepped them. Both strings appear in exactly one place — `dsh-plugin-wallpaper-engine`'s own stylesheet. No shell bundle emits either class, so both selectors match zero elements. That build uses `_7tt59G_card` and `DHFQ1a_bubble` instead.

## The fix

Split the effect into the part that can avoid class names and the part that cannot.

**Transparency → design tokens.** Both surfaces already read their background from tokens:

```css
._7tt59G_card  { background: var(--dsw-specific-input-major); }
.DHFQ1a_bubble { background: var(--dsw-specific-bubble); }
```

So overriding those two tokens under `body[data-we-wallpaper]` makes both translucent with no class name involved. This is the same mechanism the bundle already uses for `--dsw-alias-bg-base`, `--dsw-specific-sidebar-fill` and the border tokens — these two were simply not wired up the same way.

**Blur → a stable attribute.** `backdrop-filter` cannot be expressed as a token, so it still needs an element selector. The composer card carries one that is authored in the shell source rather than generated:

```js
className: clsx(InputBar_module_css_default.card, …),
"data-composer-card": true,
```

`[data-composer-card]` survives rebuilds. Message bubbles expose no equivalent attribute, so they fall back to the module-CSS `[class*="_bubble"]` suffix convention. That is a weaker guarantee, but it degrades gracefully: if the convention ever changes, the bubble is still translucent through the token override and only loses its blur.

## Why nothing else blocks it

Checked the inner elements for opaque backgrounds that would defeat a translucent card:

| element | background |
|---|---|
| `._7tt59G_card` | `var(--dsw-specific-input-major)` — now overridden |
| `._7tt59G_input` (the `<textarea>`) | `0 0` (transparent) |
| `._7tt59G_backdrop` | none |
| `.DHFQ1a_bubble` | `var(--dsw-specific-bubble)` — now overridden |

The card is the only opaque layer, so overriding the token is sufficient.

## Verification

`npm run build` regenerates `lib/client.js` from `src/client.js`; `npm run verify` passes. Against the rc.5 build the composer and bubbles now render as frosted glass, and the 玻璃 slider visibly changes the blur radius across its full 0–40px range.

Light and dark keep separate alphas, as before (0.18/0.14 light, 0.07/0.06 dark).
