### PR TITLE
feat: add playlist-scoped automatic wallpaper rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ via `libraryfolders.vdf`. Nothing further is required.
    The choice is remembered in your browser's `localStorage` (key
    `dsh-wallpaper-engine:selection`).
 
+### Automatic rotation
+
+Select a Wallpaper Engine playlist first, then enable **自动轮转**. Rotation is scoped to that playlist; the plugin never silently adds the entire inventory. The interval can be set to 1, 5, 10, 30, 60, or 120 minutes; it is off by default. At least two playable Video/Web wallpapers are required, manual changes reset the next timer, and the playlist's random/sequential order is preserved. Scene and Application wallpapers cannot be embedded in the web UI, so they are automatically excluded from rotation while remaining visible in the picker as `[不可播放]`.
+
+Playlists are read from `config.json` in the Wallpaper Engine install directory, preferring saved `general.playlists` and falling back to the active monitor playlist when no saved list exists.
+
 ### The four sliders
 
 While a wallpaper is active, four sliders let you tune how it blends with the UI:

--- a/README.zh.md
+++ b/README.zh.md
@@ -94,6 +94,12 @@ dsh plugin --profile web add link:./dsh-wallpaper-engine
 4. 用 **暂停/播放** 暂停视频壁纸，用 **关闭** 清除壁纸。
    选择会保存在浏览器的 `localStorage`（键 `dsh-wallpaper-engine:selection`）中。
 
+### 自动轮转
+
+在壁纸选择器中先选择一个 Wallpaper Engine 播放列表，再勾选 **自动轮转**，插件只会在该播放列表内循环，不会把全部壁纸一股脑加入。可选间隔为 1、5、10、30、60 或 120 分钟；默认关闭。至少需要两张可播放的 Video/Web 壁纸，手动切换壁纸会重新计算下一次轮转时间；播放列表的随机/顺序设置也会被保留。Scene 和 Application 壁纸不能嵌入网页，会自动从轮转候选中剔除，但仍会显示在选择列表中并标记为 `[不可播放]`。
+
+播放列表从 Wallpaper Engine 安装目录的 `config.json` 读取（优先使用保存的 `general.playlists`；没有保存列表时回退到当前显示器的活动列表）。
+
 ### 四个滑动条
 
 壁纸激活后，四个滑动条可以微调它与界面的融合效果：

--- a/lib/client.js
+++ b/lib/client.js
@@ -19,7 +19,15 @@ window.__ModuleLoader__.load({
 		// scrim default is intentionally LOW now: iOS liquid glass needs the wallpaper
 		// colour to pass through the glass, so we no longer crush it behind a near-black
 		// scrim. Users can raise it back via the 暗化 slider for busy wallpapers.
-		const DEFAULTS = { scrim: 0.25, border: 0.35, blur: 24, wallpaperBlur: 0 };
+		const DEFAULTS = {
+		  scrim: 0.25,
+		  border: 0.35,
+		  blur: 24,
+		  wallpaperBlur: 0,
+		  rotationEnabled: false,
+		  rotationInterval: 30,
+		  playlistId: "",
+		};
 
 		// ── Persisted selection ─────────────────────────────────────────────────────
 		function clampNum(v, lo, hi, fallback) {
@@ -37,6 +45,9 @@ window.__ModuleLoader__.load({
 		      border: clampNum(o.border, 0, 1, DEFAULTS.border),
 		      blur: clampNum(o.blur, 0, 40, DEFAULTS.blur),
 		      wallpaperBlur: clampNum(o.wallpaperBlur, 0, 60, DEFAULTS.wallpaperBlur),
+		      rotationEnabled: o.rotationEnabled === true,
+		      rotationInterval: clampNum(o.rotationInterval, 1, 1440, DEFAULTS.rotationInterval),
+		      playlistId: typeof o.playlistId === "string" ? o.playlistId : "",
 		    };
 		  } catch {
 		    return { id: "", ...DEFAULTS };
@@ -50,7 +61,8 @@ window.__ModuleLoader__.load({
 		  type: null,
 		  playing: true,
 		  loading: false,
-		  inventory: { installDir: null, wallpapers: [], total: 0, portableCount: 0, error: null },
+		  rotationTimer: null,
+		  inventory: { installDir: null, wallpapers: [], total: 0, portableCount: 0, playlists: [], error: null },
 		  loaded: false,
 		};
 
@@ -73,6 +85,9 @@ window.__ModuleLoader__.load({
 		      border: selection.border,
 		      blur: selection.blur,
 		      wallpaperBlur: selection.wallpaperBlur,
+		      rotationEnabled: selection.rotationEnabled,
+		      rotationInterval: selection.rotationInterval,
+		      playlistId: selection.playlistId,
 		    }));
 		  } catch { /* ignore */ }
 		}
@@ -89,6 +104,7 @@ window.__ModuleLoader__.load({
 		      wallpapers: data.wallpapers || [],
 		      total: data.total || 0,
 		      portableCount: data.portableCount || 0,
+		      playlists: Array.isArray(data.playlists) ? data.playlists : [],
 		      error: null,
 		    };
 		  } catch (err) {
@@ -97,20 +113,95 @@ window.__ModuleLoader__.load({
 		      wallpapers: [],
 		      total: 0,
 		      portableCount: 0,
+		      playlists: [],
 		      error: String(err && err.message ? err.message : err),
 		    };
 		  }
 		  selection.loading = false;
 		  selection.loaded = true;
 
+		  if (selection.playlistId && !selectedPlaylist()) {
+		    selection.playlistId = "";
+		    persistSelection();
+		  }
+		  if (selection.rotationEnabled && !selection.playlistId) {
+		    const firstPlaylist = firstPlayablePlaylist();
+		    if (firstPlaylist) selection.playlistId = firstPlaylist.id;
+		  }
+
 		  // After a refresh, drop the selection if the chosen wallpaper vanished or is
 		  // no longer playable (avoids a dangling media URL).
-		  if (selection.id && !selection.inventory.wallpapers.some((w) => w.id === selection.id && w.playable)) {
+		  if (selection.id && !selection.inventory.wallpapers.some((w) => w.id === selection.id && isRotatableWallpaper(w))) {
 		    selection.id = "";
 		    persistSelection();
 		  }
+		  if (selection.rotationEnabled && selection.id && !playableWallpapers().some((w) => w.id === selection.id)) {
+		    selection.id = "";
+		    persistSelection();
+		  }
+		  if (!selection.id && selection.rotationEnabled) {
+		    const first = playableWallpapers()[0];
+		    if (first) selection.id = first.id;
+		  }
 		  applySelection(selection.id);
 		  emit();
+		}
+
+		function isRotatableWallpaper(w) {
+		  return Boolean(w && w.playable && (w.type === "video" || w.type === "web"));
+		}
+
+		function selectedPlaylist() {
+		  return selection.inventory.playlists.find((p) => p.id === selection.playlistId) || null;
+		}
+
+		function playlistWallpapers(playlist) {
+		  if (!playlist || !Array.isArray(playlist.wallpaperIds)) return [];
+		  const byId = new Map(selection.inventory.wallpapers.map((w) => [w.id, w]));
+		  return playlist.wallpaperIds
+		    .map((id) => byId.get(id))
+		    .filter(isRotatableWallpaper);
+		}
+
+		function playableWallpapers() {
+		  return playlistWallpapers(selectedPlaylist());
+		}
+
+		function firstPlayablePlaylist() {
+		  return selection.inventory.playlists.find((playlist) => playlistWallpapers(playlist).length > 0) || null;
+		}
+
+		function nextRotationWallpaper() {
+		  const list = playableWallpapers();
+		  if (list.length < 2) return null;
+		  const playlist = selectedPlaylist();
+		  if (playlist && playlist.order === "random") {
+		    const candidates = list.filter((w) => w.id !== selection.id);
+		    return candidates[Math.floor(Math.random() * candidates.length)] || null;
+		  }
+		  const current = list.findIndex((w) => w.id === selection.id);
+		  return list[(current + 1 + list.length) % list.length] || null;
+		}
+
+		function clearRotationTimer() {
+		  if (selection.rotationTimer === null) return;
+		  if (typeof window !== "undefined" && typeof window.clearTimeout === "function") {
+		    window.clearTimeout(selection.rotationTimer);
+		  }
+		  selection.rotationTimer = null;
+		}
+
+		function syncRotationTimer() {
+		  clearRotationTimer();
+		  if (!selection.rotationEnabled || !selection.id) return;
+		  if (playableWallpapers().length < 2) return;
+		  if (typeof window === "undefined" || typeof window.setTimeout !== "function") return;
+		  selection.rotationTimer = window.setTimeout(() => {
+		    selection.rotationTimer = null;
+		    if (!selection.rotationEnabled || !selection.id) return;
+		    const next = nextRotationWallpaper();
+		    if (next) applySelection(next.id);
+		  }, selection.rotationInterval * 60 * 1000);
 		}
 
 		function applySelection(id) {
@@ -119,18 +210,21 @@ window.__ModuleLoader__.load({
 		  if (!selection.id) {
 		    selection.url = null;
 		    selection.type = null;
+		    syncRotationTimer();
 		    emit();
 		    return;
 		  }
 		  const w = selection.inventory.wallpapers.find((x) => x.id === selection.id);
-		  if (!w || !w.playable) {
+		  if (!w || !isRotatableWallpaper(w)) {
 		    selection.url = null;
 		    selection.type = null;
+		    syncRotationTimer();
 		    emit();
 		    return;
 		  }
 		  selection.url = w.media;
 		  selection.type = w.type;
+		  syncRotationTimer();
 		  emit();
 		}
 
@@ -261,6 +355,41 @@ window.__ModuleLoader__.load({
 		  const onTogglePlay = () => { selection.playing = !selection.playing; emit(); };
 		  const onClear = () => applySelection("");
 		  const onRefresh = () => loadInventory();
+		  const onPlaylistChange = (e) => {
+		    selection.playlistId = e.target.value;
+		    const first = playableWallpapers()[0];
+		    if (selection.rotationEnabled) {
+		      if (first) applySelection(first.id);
+		      else applySelection("");
+		      return;
+		    }
+		    persistSelection();
+		    syncRotationTimer();
+		    emit();
+		  };
+		  const onToggleRotation = () => {
+		    selection.rotationEnabled = !selection.rotationEnabled;
+		    if (selection.rotationEnabled && !selection.playlistId) {
+		      const firstPlaylist = firstPlayablePlaylist();
+		      if (firstPlaylist) selection.playlistId = firstPlaylist.id;
+		    }
+		    if (selection.rotationEnabled && !playableWallpapers().some((w) => w.id === selection.id)) {
+		      const first = playableWallpapers()[0];
+		      if (first) {
+		        applySelection(first.id);
+		        return;
+		      }
+		    }
+		    persistSelection();
+		    syncRotationTimer();
+		    emit();
+		  };
+		  const onRotationInterval = (e) => {
+		    selection.rotationInterval = clampNum(Number(e.target.value), 1, 1440, DEFAULTS.rotationInterval);
+		    persistSelection();
+		    syncRotationTimer();
+		    emit();
+		  };
 
 		  // Slider callbacks: keep the stored value in its canonical unit, then apply
 		  // the effect IMMEDIATELY (applyEffects writes the CSS var synchronously) so
@@ -285,12 +414,15 @@ window.__ModuleLoader__.load({
 		  }
 
 		  const list = sel.inventory.wallpapers;
+		  const playlists = sel.inventory.playlists;
+		  const playlist = selectedPlaylist();
+		  const playableCount = playableWallpapers().length;
 		  return React.createElement("div", { className: "we-picker" },
 		    React.createElement("select", { className: "we-picker__select", value: sel.id, onChange },
 		      React.createElement("option", { value: "" }, "— 无（关闭） —"),
 		      ...list.map((w) => React.createElement("option", {
-		        key: w.id, value: w.id, disabled: !w.playable,
-		      }, (w.playable ? "" : "[不可播放] ") + w.title)),
+		        key: w.id, value: w.id, disabled: !isRotatableWallpaper(w),
+		      }, (isRotatableWallpaper(w) ? "" : "[不可播放] ") + w.title)),
 		    ),
 		    React.createElement("div", { className: "we-picker__row" },
 		      React.createElement("button", {
@@ -306,6 +438,43 @@ window.__ModuleLoader__.load({
 		        onClick: onRefresh, disabled: sel.loading,
 		      }, sel.loading ? "刷新中…" : "刷新"),
 		    ),
+		    React.createElement("div", { className: "we-picker__row we-picker__playlist-row" },
+		      React.createElement("span", { className: "we-picker__hint we-picker__label" }, "播放列表"),
+		      React.createElement("select", {
+		        className: "we-picker__playlist-select",
+		        value: sel.playlistId,
+		        onChange: onPlaylistChange,
+		        disabled: playlists.length === 0,
+		      },
+		      React.createElement("option", { value: "" }, playlists.length ? "— 选择播放列表 —" : "— 未检测到播放列表 —"),
+		      ...playlists.map((p) => React.createElement("option", {
+		        key: p.id, value: p.id,
+		      }, p.name + "（" + (p.portableCount || 0) + " 可播放）")),
+		      ),
+		    ),
+		    React.createElement("div", { className: "we-picker__row we-picker__rotation-row" },
+		      React.createElement("label", { className: "we-picker__rotation-toggle" },
+		        React.createElement("input", {
+		          type: "checkbox",
+		          checked: sel.rotationEnabled,
+		          onChange: onToggleRotation,
+		          disabled: !sel.playlistId || playableCount < 2,
+		        }),
+		        "自动轮转",
+		      ),
+		      React.createElement("select", {
+		        className: "we-picker__rotation-interval",
+		        value: String(sel.rotationInterval),
+		        onChange: onRotationInterval,
+		        disabled: !sel.rotationEnabled || !sel.playlistId || playableCount < 2,
+		        title: "自动轮转间隔",
+		      },
+		      ...[1, 5, 10, 30, 60, 120].map((minutes) =>
+		        React.createElement("option", { key: minutes, value: String(minutes) }, minutes + " 分钟"),
+		      )),
+		      !sel.playlistId && React.createElement("span", { className: "we-picker__hint" }, "请先选择播放列表"),
+		      sel.playlistId && playableCount < 2 && React.createElement("span", { className: "we-picker__hint" }, "当前播放列表至少需要 2 个可播放壁纸"),
+		    ),
 		    sel.id && React.createElement(React.Fragment, null,
 		      SliderRow("壁纸模糊", 0, 60, 1, sel.wallpaperBlur, onWallpaperBlur, sel.wallpaperBlur + "px"),
 		      SliderRow("暗化", 0, 90, 5, Math.round(sel.scrim * 100), onScrim, Math.round(sel.scrim * 100) + "%"),
@@ -314,7 +483,10 @@ window.__ModuleLoader__.load({
 		    ),
 		    React.createElement("div", { className: "we-picker__row" },
 		      React.createElement("span", { className: "we-picker__hint" },
-		        list.length + " 个壁纸 · " + sel.inventory.portableCount + " 可播放"),
+		        (playlist
+		          ? playlist.name + "：" + (playlist.total || 0) + " 项 · " + playableCount + " 可播放"
+		          : list.length + " 个壁纸 · " + sel.inventory.portableCount + " 可播放") +
+		        (sel.rotationEnabled ? " · 每 " + sel.rotationInterval + " 分钟轮转" : "")),
 		    ),
 		  );
 		}
@@ -411,6 +583,9 @@ window.__ModuleLoader__.load({
 		  .we-picker { display: flex; flex-direction: column; gap: 8px; }
 		  .we-picker__select { max-width: 100%; }
 		  .we-picker__row { display: flex; gap: 8px; align-items: center; }
+		  .we-picker__playlist-select { flex: 1; min-width: 0; }
+		  .we-picker__rotation-toggle { display: inline-flex; align-items: center; gap: 6px; }
+		  .we-picker__rotation-interval { margin-left: auto; }
 		  .we-picker__btn { cursor: pointer; }
 		  .we-picker__hint { font-size: 0.8em; opacity: 0.7; }
 		  .we-picker__error { font-size: 0.85em; opacity: 0.8; }
@@ -445,6 +620,7 @@ window.__ModuleLoader__.load({
 		      return () => {
 		        unsub();
 		        unsubEffects();
+		        clearRotationTimer();
 		        const node = document.getElementById(LAYER_ID);
 		        if (node) node.remove();
 		        const scrim = document.getElementById(SCRIM_ID);

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@
  *      their preview image is served (they cannot be rendered here — see README).
  *   3. Serve a JSON inventory and the media/preview bytes over loopback HTTP
  *      routes the browser half fetches directly (same-origin):
- *        GET /wallpaper-engine/inventory          → { installDir, wallpapers:[…] }
+ *        GET /wallpaper-engine/inventory          → { installDir, wallpapers:[…], playlists:[…] }
  *        GET /wallpaper-engine/media/<token>      → video / html (Range supported)
  *        GET /wallpaper-engine/preview/<token>    → preview image
  *
@@ -171,6 +171,66 @@ function enumerateWallpapers(installDir, libraryDirs) {
     (a.title || '').localeCompare(b.title || ''));
 }
 
+function pathKey(file) {
+  return normalize(String(file).replace(/\//g, '\\')).toLowerCase();
+}
+
+function playlistId(profileName, index, name) {
+  return Buffer.from(`${profileName}\0${index}\0${name}`, 'utf8').toString('base64url');
+}
+
+function playlistRows(profile) {
+  const general = profile && typeof profile === 'object' ? profile.general : null;
+  if (!general || typeof general !== 'object') return [];
+  if (Array.isArray(general.playlists) && general.playlists.length) return general.playlists;
+  const selected = general.wallpaperconfig && general.wallpaperconfig.selectedwallpapers;
+  if (!selected || typeof selected !== 'object') return [];
+  return Object.values(selected)
+    .map((monitor) => monitor && monitor.playlist)
+    .filter((playlist) => playlist && typeof playlist === 'object');
+}
+
+function readPlaylists(installDir) {
+  if (!installDir) return [];
+  const configPath = join(installDir, 'config.json');
+  if (!existsSync(configPath)) return [];
+  let config;
+  try { config = JSON.parse(readFileSync(configPath, 'utf8')); } catch { return []; }
+
+  const result = [];
+  const seen = new Set();
+  for (const [profileName, profile] of Object.entries(config || {})) {
+    for (const [index, row] of playlistRows(profile).entries()) {
+      const items = Array.isArray(row.items)
+        ? row.items.filter((item) => typeof item === 'string' && item.trim())
+        : [];
+      if (!items.length) continue;
+      const name = typeof row.name === 'string' && row.name.trim()
+        ? row.name.trim() : `Playlist ${index + 1}`;
+      const signature = `${name}\0${items.join('\0')}`;
+      if (seen.has(signature)) continue;
+      seen.add(signature);
+      const settings = row.settings && typeof row.settings === 'object' ? row.settings : {};
+      result.push({
+        id: playlistId(profileName, index, name),
+        name,
+        items,
+        order: settings.order === 'random' ? 'random' : 'sequence',
+        delay: typeof settings.delay === 'number' ? settings.delay : null,
+      });
+    }
+  }
+  return result;
+}
+
+function playlistItemId(item, byPath, byId) {
+  const exact = byPath.get(pathKey(item));
+  if (exact) return exact;
+  const match = /[\\/]431960[\\/]([^\\/]+)(?:[\\/]|$)/i.exec(item);
+  const project = match ? byId.get(match[1]) : null;
+  return project ? project.id : null;
+}
+
 function mimeFor(absPath) {
   const ext = absPath.slice(absPath.lastIndexOf('.') + 1).toLowerCase();
   return {
@@ -213,6 +273,8 @@ export function apply(ctx) {
     const installDir = locateWallpaperEngine();
     const libraryDirs = owningLibraries();
     const all = enumerateWallpapers(installDir, libraryDirs);
+    const byPath = new Map(all.map((w) => [pathKey(w.fileAbs), w.id]));
+    const byId = new Map(all.map((w) => [w.id, w]));
     const wallpapers = all.map((w) => {
       const hasMedia = w.type === 'video' || w.type === 'web'
         ? existsSync(w.fileAbs) : false;
@@ -226,11 +288,31 @@ export function apply(ctx) {
         preview: hasPreview ? `${BASE}/preview/${tokenFor(w.previewAbs)}` : null,
       };
     });
+    const playableIds = new Set(wallpapers.filter((w) => w.playable).map((w) => w.id));
+    const playlists = readPlaylists(installDir).map((playlist) => {
+      const ids = [];
+      const seenIds = new Set();
+      for (const item of playlist.items) {
+        const id = playlistItemId(item, byPath, byId);
+        if (id && !seenIds.has(id)) { seenIds.add(id); ids.push(id); }
+      }
+      return {
+        id: playlist.id,
+        name: playlist.name,
+        order: playlist.order,
+        delay: playlist.delay,
+        wallpaperIds: ids,
+        total: ids.length,
+        portableCount: ids.filter((id) => playableIds.has(id)).length,
+        unresolvedCount: Math.max(0, playlist.items.length - ids.length),
+      };
+    });
     return {
       installDir,
       total: wallpapers.length,
       portableCount: wallpapers.filter((w) => w.playable).length,
       wallpapers,
+      playlists,
     };
   }
 

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -25,6 +25,26 @@ export interface WallpaperDescriptor {
   preview: string | null;
 }
 
+/** A Wallpaper Engine playlist read from `config.json`. */
+export interface PlaylistDescriptor {
+  /** Stable identifier derived from the Wallpaper Engine profile and index. */
+  id: string;
+  /** Playlist name shown in the picker. */
+  name: string;
+  /** Wallpaper Engine ordering mode (`sequence` or `random`). */
+  order: 'sequence' | 'random';
+  /** Wallpaper Engine delay in seconds, when present. */
+  delay: number | null;
+  /** Inventory ids in the playlist order. */
+  wallpaperIds: string[];
+  /** Number of resolved entries in the playlist. */
+  total: number;
+  /** Number of resolved Video/Web entries. */
+  portableCount: number;
+  /** Number of config entries that could not be matched to the inventory. */
+  unresolvedCount: number;
+}
+
 /** Shape returned by GET /wallpaper-engine/inventory. */
 export interface Inventory {
   /** Absolute Wallpaper Engine install dir, or null when not found. */
@@ -35,6 +55,8 @@ export interface Inventory {
   portableCount: number;
   /** All installed wallpapers. */
   wallpapers: WallpaperDescriptor[];
+  /** Saved Wallpaper Engine playlists available for scoped rotation. */
+  playlists: PlaylistDescriptor[];
 }
 
 /** The host plugin hard-depends on the webserver service (`webServer`). */

--- a/scripts/verify-client.mjs
+++ b/scripts/verify-client.mjs
@@ -1,7 +1,8 @@
 // Verify the emitted client bundle materializes + drives the DOM correctly
 // under the DSH module-loader contract. Exercises apply(), syncLayers(), and
 // confirms: wallpaper + scrim layers are `<body>` children (no shell.overlay),
-// and the three effect knobs (scrim/border/blur) push CSS variables.
+// the four effect knobs (wallpaper blur/scrim/border/glass blur) push CSS
+// variables, and rotation stays scoped to a playlist.
 import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
 
@@ -14,6 +15,7 @@ const React = {
 };
 
 let byId = {};
+const rotationTimers = [];
 function makeEl(tag) {
   return {
     tagName: tag.toUpperCase(),
@@ -40,9 +42,9 @@ const document = {
 };
 
 const localStorage = {
-  // Select a wallpaper but omit effect knobs → the new DEFAULTS
-  // (scrim 0.25, border 0.35, blur 24) should apply.
-  _store: { 'dsh-wallpaper-engine:selection': JSON.stringify({ id: 'a' }) },
+  // Select a wallpaper and enable rotation; omit effect knobs so the new
+  // DEFAULTS (scrim 0.25, border 0.35, blur 24) should apply.
+  _store: { 'dsh-wallpaper-engine:selection': JSON.stringify({ id: 'a', playlistId: 'p1', rotationEnabled: true, rotationInterval: 5 }) },
   getItem(k) { return this._store[k] ?? null; },
   setItem(k, v) { this._store[k] = v; },
 };
@@ -50,16 +52,31 @@ const fetch = () => Promise.resolve({
   ok: true, status: 200,
   json: () => Promise.resolve({
     installDir: "D:/we", total: 3, portableCount: 2,
+    playlists: [
+      { id: "p1", name: "Test playlist", order: "sequence", wallpaperIds: ["a", "b", "c"], total: 3, portableCount: 2 },
+    ],
     wallpapers: [
       { id: "a", title: "Video A", type: "video", playable: true, media: "/wallpaper-engine/media/xyz", preview: null },
-      { id: "b", title: "Scene B", type: "scene", playable: false, media: null, preview: null },
+      { id: "b", title: "Video B", type: "video", playable: true, media: "/wallpaper-engine/media/def", preview: null },
+      { id: "c", title: "Scene C", type: "scene", playable: false, media: null, preview: null },
     ],
   }),
 });
 
 const code = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8');
 const cap = { handoff: null };
-const sandbox = { window: { __ModuleLoader__: { load: (h) => { cap.handoff = h; } } }, document, localStorage, fetch, React };
+const sandbox = {
+  window: {
+    __ModuleLoader__: { load: (h) => { cap.handoff = h; } },
+    setTimeout: (fn, ms) => {
+      const token = { fn, ms, cleared: false };
+      rotationTimers.push(token);
+      return token;
+    },
+    clearTimeout: (token) => { if (token) token.cleared = true; },
+  },
+  document, localStorage, fetch, React,
+};
 vm.createContext(sandbox);
 new vm.Script(code, { filename: 'client.js' }).runInContext(sandbox);
 
@@ -96,6 +113,17 @@ setTimeout(() => {
   console.log('--we-blur:', JSON.stringify(p['--we-blur']));
   console.log('--we-wallpaper-blur:', JSON.stringify(p['--we-wallpaper-blur']));
   console.log('--we-wallpaper-scale:', JSON.stringify(p['--we-wallpaper-scale']));
+  const timer = rotationTimers.find((item) => !item.cleared);
+  console.log('rotation timer scheduled:', !!timer, timer ? timer.ms : null);
+  if (timer) {
+    timer.fn();
+    console.log('rotation next id:', JSON.parse(localStorage._store['dsh-wallpaper-engine:selection']).id);
+    const wrapTimer = rotationTimers.find((item) => !item.cleared);
+    if (wrapTimer) {
+      wrapTimer.fn();
+      console.log('rotation wraps to id:', JSON.parse(localStorage._store['dsh-wallpaper-engine:selection']).id);
+    }
+  }
   console.log('effects ran:', effects.length);
   console.log('\nALL CLIENT CHECKS DONE');
 }, 50);

--- a/src/client.js
+++ b/src/client.js
@@ -12,7 +12,8 @@
  *      z-index:-1` child of `document.body`, plus a scrim (darkened overlay). The
  *      app frame + sidebar backgrounds are made transparent so the wallpaper
  *      shows through the whole frame while the scrim keeps text readable.
- *   3. Applies three user-adjustable effects, each with its own slider:
+ *   3. Applies four user-adjustable effects, each with its own slider:
+ *      - 壁纸模糊 (wallpaper blur) → `--we-wallpaper-blur`
  *      - 暗化 (scrim strength)      → `--we-scrim-color`
  *      - 边框 (border emphasis)     → `--dsw-alias-border-l1/l2` alpha
  *      - 玻璃 (glass blur on panels)→ `--we-blur` + frosted-glass backgrounds
@@ -35,7 +36,15 @@ const SCRIM_ID = "dsh-wallpaper-engine-scrim";
 // scrim default is intentionally LOW now: iOS liquid glass needs the wallpaper
 // colour to pass through the glass, so we no longer crush it behind a near-black
 // scrim. Users can raise it back via the 暗化 slider for busy wallpapers.
-const DEFAULTS = { scrim: 0.25, border: 0.35, blur: 24, wallpaperBlur: 0 };
+const DEFAULTS = {
+  scrim: 0.25,
+  border: 0.35,
+  blur: 24,
+  wallpaperBlur: 0,
+  rotationEnabled: false,
+  rotationInterval: 30,
+  playlistId: "",
+};
 
 // ── Persisted selection ─────────────────────────────────────────────────────
 function clampNum(v, lo, hi, fallback) {
@@ -53,6 +62,9 @@ function readPersisted() {
       border: clampNum(o.border, 0, 1, DEFAULTS.border),
       blur: clampNum(o.blur, 0, 40, DEFAULTS.blur),
       wallpaperBlur: clampNum(o.wallpaperBlur, 0, 60, DEFAULTS.wallpaperBlur),
+      rotationEnabled: o.rotationEnabled === true,
+      rotationInterval: clampNum(o.rotationInterval, 1, 1440, DEFAULTS.rotationInterval),
+      playlistId: typeof o.playlistId === "string" ? o.playlistId : "",
     };
   } catch {
     return { id: "", ...DEFAULTS };
@@ -66,7 +78,8 @@ const selection = {
   type: null,
   playing: true,
   loading: false,
-  inventory: { installDir: null, wallpapers: [], total: 0, portableCount: 0, error: null },
+  rotationTimer: null,
+  inventory: { installDir: null, wallpapers: [], total: 0, portableCount: 0, playlists: [], error: null },
   loaded: false,
 };
 
@@ -89,6 +102,9 @@ function persistSelection() {
       border: selection.border,
       blur: selection.blur,
       wallpaperBlur: selection.wallpaperBlur,
+      rotationEnabled: selection.rotationEnabled,
+      rotationInterval: selection.rotationInterval,
+      playlistId: selection.playlistId,
     }));
   } catch { /* ignore */ }
 }
@@ -105,6 +121,7 @@ async function loadInventory() {
       wallpapers: data.wallpapers || [],
       total: data.total || 0,
       portableCount: data.portableCount || 0,
+      playlists: Array.isArray(data.playlists) ? data.playlists : [],
       error: null,
     };
   } catch (err) {
@@ -113,20 +130,95 @@ async function loadInventory() {
       wallpapers: [],
       total: 0,
       portableCount: 0,
+      playlists: [],
       error: String(err && err.message ? err.message : err),
     };
   }
   selection.loading = false;
   selection.loaded = true;
 
+  if (selection.playlistId && !selectedPlaylist()) {
+    selection.playlistId = "";
+    persistSelection();
+  }
+  if (selection.rotationEnabled && !selection.playlistId) {
+    const firstPlaylist = firstPlayablePlaylist();
+    if (firstPlaylist) selection.playlistId = firstPlaylist.id;
+  }
+
   // After a refresh, drop the selection if the chosen wallpaper vanished or is
   // no longer playable (avoids a dangling media URL).
-  if (selection.id && !selection.inventory.wallpapers.some((w) => w.id === selection.id && w.playable)) {
+  if (selection.id && !selection.inventory.wallpapers.some((w) => w.id === selection.id && isRotatableWallpaper(w))) {
     selection.id = "";
     persistSelection();
   }
+  if (selection.rotationEnabled && selection.id && !playableWallpapers().some((w) => w.id === selection.id)) {
+    selection.id = "";
+    persistSelection();
+  }
+  if (!selection.id && selection.rotationEnabled) {
+    const first = playableWallpapers()[0];
+    if (first) selection.id = first.id;
+  }
   applySelection(selection.id);
   emit();
+}
+
+function isRotatableWallpaper(w) {
+  return Boolean(w && w.playable && (w.type === "video" || w.type === "web"));
+}
+
+function selectedPlaylist() {
+  return selection.inventory.playlists.find((p) => p.id === selection.playlistId) || null;
+}
+
+function playlistWallpapers(playlist) {
+  if (!playlist || !Array.isArray(playlist.wallpaperIds)) return [];
+  const byId = new Map(selection.inventory.wallpapers.map((w) => [w.id, w]));
+  return playlist.wallpaperIds
+    .map((id) => byId.get(id))
+    .filter(isRotatableWallpaper);
+}
+
+function playableWallpapers() {
+  return playlistWallpapers(selectedPlaylist());
+}
+
+function firstPlayablePlaylist() {
+  return selection.inventory.playlists.find((playlist) => playlistWallpapers(playlist).length > 0) || null;
+}
+
+function nextRotationWallpaper() {
+  const list = playableWallpapers();
+  if (list.length < 2) return null;
+  const playlist = selectedPlaylist();
+  if (playlist && playlist.order === "random") {
+    const candidates = list.filter((w) => w.id !== selection.id);
+    return candidates[Math.floor(Math.random() * candidates.length)] || null;
+  }
+  const current = list.findIndex((w) => w.id === selection.id);
+  return list[(current + 1 + list.length) % list.length] || null;
+}
+
+function clearRotationTimer() {
+  if (selection.rotationTimer === null) return;
+  if (typeof window !== "undefined" && typeof window.clearTimeout === "function") {
+    window.clearTimeout(selection.rotationTimer);
+  }
+  selection.rotationTimer = null;
+}
+
+function syncRotationTimer() {
+  clearRotationTimer();
+  if (!selection.rotationEnabled || !selection.id) return;
+  if (playableWallpapers().length < 2) return;
+  if (typeof window === "undefined" || typeof window.setTimeout !== "function") return;
+  selection.rotationTimer = window.setTimeout(() => {
+    selection.rotationTimer = null;
+    if (!selection.rotationEnabled || !selection.id) return;
+    const next = nextRotationWallpaper();
+    if (next) applySelection(next.id);
+  }, selection.rotationInterval * 60 * 1000);
 }
 
 function applySelection(id) {
@@ -135,18 +227,21 @@ function applySelection(id) {
   if (!selection.id) {
     selection.url = null;
     selection.type = null;
+    syncRotationTimer();
     emit();
     return;
   }
   const w = selection.inventory.wallpapers.find((x) => x.id === selection.id);
-  if (!w || !w.playable) {
+  if (!w || !isRotatableWallpaper(w)) {
     selection.url = null;
     selection.type = null;
+    syncRotationTimer();
     emit();
     return;
   }
   selection.url = w.media;
   selection.type = w.type;
+  syncRotationTimer();
   emit();
 }
 
@@ -277,6 +372,41 @@ function WallpaperPicker() {
   const onTogglePlay = () => { selection.playing = !selection.playing; emit(); };
   const onClear = () => applySelection("");
   const onRefresh = () => loadInventory();
+  const onPlaylistChange = (e) => {
+    selection.playlistId = e.target.value;
+    const first = playableWallpapers()[0];
+    if (selection.rotationEnabled) {
+      if (first) applySelection(first.id);
+      else applySelection("");
+      return;
+    }
+    persistSelection();
+    syncRotationTimer();
+    emit();
+  };
+  const onToggleRotation = () => {
+    selection.rotationEnabled = !selection.rotationEnabled;
+    if (selection.rotationEnabled && !selection.playlistId) {
+      const firstPlaylist = firstPlayablePlaylist();
+      if (firstPlaylist) selection.playlistId = firstPlaylist.id;
+    }
+    if (selection.rotationEnabled && !playableWallpapers().some((w) => w.id === selection.id)) {
+      const first = playableWallpapers()[0];
+      if (first) {
+        applySelection(first.id);
+        return;
+      }
+    }
+    persistSelection();
+    syncRotationTimer();
+    emit();
+  };
+  const onRotationInterval = (e) => {
+    selection.rotationInterval = clampNum(Number(e.target.value), 1, 1440, DEFAULTS.rotationInterval);
+    persistSelection();
+    syncRotationTimer();
+    emit();
+  };
 
   // Slider callbacks: keep the stored value in its canonical unit, then apply
   // the effect IMMEDIATELY (applyEffects writes the CSS var synchronously) so
@@ -301,12 +431,15 @@ function WallpaperPicker() {
   }
 
   const list = sel.inventory.wallpapers;
+  const playlists = sel.inventory.playlists;
+  const playlist = selectedPlaylist();
+  const playableCount = playableWallpapers().length;
   return React.createElement("div", { className: "we-picker" },
     React.createElement("select", { className: "we-picker__select", value: sel.id, onChange },
       React.createElement("option", { value: "" }, "— 无（关闭） —"),
       ...list.map((w) => React.createElement("option", {
-        key: w.id, value: w.id, disabled: !w.playable,
-      }, (w.playable ? "" : "[不可播放] ") + w.title)),
+        key: w.id, value: w.id, disabled: !isRotatableWallpaper(w),
+      }, (isRotatableWallpaper(w) ? "" : "[不可播放] ") + w.title)),
     ),
     React.createElement("div", { className: "we-picker__row" },
       React.createElement("button", {
@@ -322,6 +455,43 @@ function WallpaperPicker() {
         onClick: onRefresh, disabled: sel.loading,
       }, sel.loading ? "刷新中…" : "刷新"),
     ),
+    React.createElement("div", { className: "we-picker__row we-picker__playlist-row" },
+      React.createElement("span", { className: "we-picker__hint we-picker__label" }, "播放列表"),
+      React.createElement("select", {
+        className: "we-picker__playlist-select",
+        value: sel.playlistId,
+        onChange: onPlaylistChange,
+        disabled: playlists.length === 0,
+      },
+      React.createElement("option", { value: "" }, playlists.length ? "— 选择播放列表 —" : "— 未检测到播放列表 —"),
+      ...playlists.map((p) => React.createElement("option", {
+        key: p.id, value: p.id,
+      }, p.name + "（" + (p.portableCount || 0) + " 可播放）")),
+      ),
+    ),
+    React.createElement("div", { className: "we-picker__row we-picker__rotation-row" },
+      React.createElement("label", { className: "we-picker__rotation-toggle" },
+        React.createElement("input", {
+          type: "checkbox",
+          checked: sel.rotationEnabled,
+          onChange: onToggleRotation,
+          disabled: !sel.playlistId || playableCount < 2,
+        }),
+        "自动轮转",
+      ),
+      React.createElement("select", {
+        className: "we-picker__rotation-interval",
+        value: String(sel.rotationInterval),
+        onChange: onRotationInterval,
+        disabled: !sel.rotationEnabled || !sel.playlistId || playableCount < 2,
+        title: "自动轮转间隔",
+      },
+      ...[1, 5, 10, 30, 60, 120].map((minutes) =>
+        React.createElement("option", { key: minutes, value: String(minutes) }, minutes + " 分钟"),
+      )),
+      !sel.playlistId && React.createElement("span", { className: "we-picker__hint" }, "请先选择播放列表"),
+      sel.playlistId && playableCount < 2 && React.createElement("span", { className: "we-picker__hint" }, "当前播放列表至少需要 2 个可播放壁纸"),
+    ),
     sel.id && React.createElement(React.Fragment, null,
       SliderRow("壁纸模糊", 0, 60, 1, sel.wallpaperBlur, onWallpaperBlur, sel.wallpaperBlur + "px"),
       SliderRow("暗化", 0, 90, 5, Math.round(sel.scrim * 100), onScrim, Math.round(sel.scrim * 100) + "%"),
@@ -330,7 +500,10 @@ function WallpaperPicker() {
     ),
     React.createElement("div", { className: "we-picker__row" },
       React.createElement("span", { className: "we-picker__hint" },
-        list.length + " 个壁纸 · " + sel.inventory.portableCount + " 可播放"),
+        (playlist
+          ? playlist.name + "：" + (playlist.total || 0) + " 项 · " + playableCount + " 可播放"
+          : list.length + " 个壁纸 · " + sel.inventory.portableCount + " 可播放") +
+        (sel.rotationEnabled ? " · 每 " + sel.rotationInterval + " 分钟轮转" : "")),
     ),
   );
 }
@@ -427,6 +600,9 @@ const CSS = `
   .we-picker { display: flex; flex-direction: column; gap: 8px; }
   .we-picker__select { max-width: 100%; }
   .we-picker__row { display: flex; gap: 8px; align-items: center; }
+  .we-picker__playlist-select { flex: 1; min-width: 0; }
+  .we-picker__rotation-toggle { display: inline-flex; align-items: center; gap: 6px; }
+  .we-picker__rotation-interval { margin-left: auto; }
   .we-picker__btn { cursor: pointer; }
   .we-picker__hint { font-size: 0.8em; opacity: 0.7; }
   .we-picker__error { font-size: 0.85em; opacity: 0.8; }
@@ -461,6 +637,7 @@ function apply(ctx) {
       return () => {
         unsub();
         unsubEffects();
+        clearRotationTimer();
         const node = document.getElementById(LAYER_ID);
         if (node) node.remove();
         const scrim = document.getElementById(SCRIM_ID);


### PR DESCRIPTION
## 概述

为 `dsh-wallpaper-engine` 增加基于 Wallpaper Engine 播放列表的自动轮转能力，让 dsh 可以按照用户选定的播放列表定时切换壁纸，同时保持现有的手动选择、播放控制和视觉调节功能。

## 主要改动

- 从 Wallpaper Engine 安装目录的 `config.json` 读取播放列表：优先使用保存的 `general.playlists`，没有保存列表时回退到当前显示器的活动播放列表。
- 在壁纸选择器中增加“播放列表”下拉框，并展示当前列表的总项目数与可播放项目数。
- 自动轮转严格限定在选中的播放列表内，不会把整个 Wallpaper Engine 库一股脑加入轮转。
- 保留播放列表自身的 `random` / `sequence` 顺序设置；随机列表按随机顺序挑选，顺序列表按列表顺序循环。
- 增加 1、5、10、30、60、120 分钟轮转间隔，默认关闭；只有列表中至少有两个可播放项目时才允许开启。
- 手动切换壁纸时重新计算下一次轮转时间，避免刚刚手动选择后立即被定时器覆盖。
- 轮转候选只包含网页可以嵌入的 Video/Web 壁纸；Scene 和 Application 会从轮转候选中自动剔除，但仍保留在选择器中并标记为 `[不可播放]`。
- 将播放列表、轮转开关和间隔保存到浏览器 `localStorage`，刷新后恢复用户选择。
- 扩展 inventory 数据与样式，补充播放列表选择器、轮转控件和状态提示。

## 关于 Scene / Application 场景

Wallpaper Engine 的 Scene/Application 类型依赖桌面端渲染能力，当前 dsh 网页层无法直接嵌入，因此本 PR 不会尝试在网页中轮转这些类型。它们会明确显示为 `[不可播放]` 并从候选集合排除；如果选定列表中没有至少两个 Video/Web 项目，自动轮转开关会保持不可用。

## 验证情况

- `node --check lib/index.js`
- `npm run build`
- `npm run verify`
- 已在本机运行的 dsh Web (`http://127.0.0.1:3080`) 上验证 `/wallpaper-engine/inventory` 返回播放列表数据。
- 实测播放列表“壁纸”共 33 项：21 个 Scene、11 个 Video、1 个 Web；其中 12 项可用于网页轮转，`unresolvedCount=0`。

## 兼容性与注意事项

- 未选播放列表时不会启动自动轮转。
- 轮转不会改变 Wallpaper Engine 原有播放列表内容，只读取配置并在网页侧进行切换。
- 现有的壁纸预览、暂停/播放、关闭、模糊/暗化/边框等功能保持不变。