### PR TITLE
fix: abort stale fps-cap transcode when the cap switches (24→48)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1192,6 +1192,13 @@ window.__ModuleLoader__.load({
 		          } else {
 		            maybeUpgradeToTranscoded(video, token);
 		          }
+		        } else {
+		          // The layer/video was rebuilt while this request was in flight (e.g.
+		          // Edge 兼容 render-mode toggle, or a wallpaper switch that raced the
+		          // abort): re-run syncLayers so the CURRENT video gets its own fresh
+		          // upgrade decision — otherwise it would sit on the original (full
+		          // decode) until some unrelated emit happened to re-trigger it.
+		          emit();
 		        }
 		        return;
 		      }

--- a/lib/client.js
+++ b/lib/client.js
@@ -715,6 +715,10 @@ window.__ModuleLoader__.load({
 		  // Keep the preview around so a failed static frame can fall back to it.
 		  selection.previewUrl = w.preview || null;
 		  selection.transcodeState = "idle";
+		  // The previous wallpaper's media info must not leak into the new one: a stale
+		  // fps would make the sync "源帧率 ≤ 上限" check wrongly skip the transcode
+		  // (and the UI would keep claiming 无需抽帧 for a 120fps source).
+		  selection.mediaInfo = null;
 		  abortTranscodeUpgrade();
 		  refreshMediaInfo();
 		  syncRotationTimer();
@@ -1051,6 +1055,11 @@ window.__ModuleLoader__.load({
 		      const mi = selection.mediaInfo;
 		      if (mi && mi.fps && mi.fps > 0 && selection.fpsCap > 0 && mi.fps <= selection.fpsCap) {
 		        abortTranscodeUpgrade();
+		        // Also drop a swapped transcode from a previous LOWER cap, so the
+		        // "无需抽帧" hint matches what is actually playing (the original).
+		        const layer = document.getElementById(LAYER_ID);
+		        const video = layer && layer.querySelector("video");
+		        if (video && video.dataset.weTranscoded) revertTranscodedVideo(video);
 		        selection.transcodeState = "skipped";
 		      }
 		      emit();
@@ -1062,6 +1071,13 @@ window.__ModuleLoader__.load({
 
 		let upgradeAbort = null;
 		let upgradeToken = "";
+		// The fps cap the in-flight upgrade request targets (0 = none). The in-flight
+		// latch is keyed by token ONLY in the old code, so switching 24→48 while the
+		// 24fps transcode was still running was treated as "already working on it" —
+		// the stale 24fps request then completed and swapped the video to a 24fps
+		// re-encode while the picker advertised the new cap ("已切换至 48fps 抽帧版").
+		// Tracking the cap lets a cap change abort the stale request and start fresh.
+		let upgradeFps = 0;
 		let upgradePollTimer = null; // progress poller while the transcode fetch pends
 		function clearUpgradePoll() {
 		  if (upgradePollTimer) { clearInterval(upgradePollTimer); upgradePollTimer = null; }
@@ -1070,6 +1086,7 @@ window.__ModuleLoader__.load({
 		  clearUpgradePoll();
 		  if (upgradeAbort) { upgradeAbort.abort(); upgradeAbort = null; }
 		  upgradeToken = "";
+		  upgradeFps = 0;
 		  selection.transcodeProgress = null;
 		}
 		// Revert a video that was swapped to a capped-fps transcode back to the source.
@@ -1103,15 +1120,24 @@ window.__ModuleLoader__.load({
 		    return;
 		  }
 		  if (video.dataset.weTranscoded === String(cap)) return; // already on this cap
-		  if (!video.dataset.weTranscoded && upgradeToken === token && upgradeAbort) return; // working on it
+		  // Only an in-flight request for THIS cap counts as "working on it": a request
+		  // for a different cap would complete and swap in a stale-fps re-encode while
+		  // the picker advertises the current cap (24→48 direct switch bug). The guard
+		  // is deliberately NOT conditioned on weTranscoded: the progress poller emits
+		  // (→ syncLayers → this function), and with the video already on a transcode
+		  // that emit used to abort + re-start the request forever (page freeze).
+		  if (upgradeToken === token && upgradeAbort && upgradeFps === cap) return; // already working on this cap
 		  abortTranscodeUpgrade();
 		  upgradeToken = token;
+		  upgradeFps = cap;
 		  const ctrl = new AbortController();
 		  upgradeAbort = ctrl;
 		  selection.transcodeState = "working";
 		  selection.transcodeProgress = null;
 		  // Progress poller: 500ms interval reading /transcode-progress (download %,
-		  // then frame-based transcode % + ETA). Cleared on settle/abort.
+		  // then frame-based transcode % + ETA). Cleared on settle/abort. The timer is
+		  // ALSO kept in this closure so THIS request's completion only ever clears its
+		  // OWN timer — a stale request must not kill the newer request's poller.
 		  const pollProgress = () => {
 		    if (ctrl.signal.aborted) return;
 		    fetch("/wallpaper-engine/transcode-progress/" + encodeURIComponent(token) + "?fps=" + cap, { cache: "no-store" })
@@ -1135,7 +1161,8 @@ window.__ModuleLoader__.load({
 		      .catch(() => { /* transient poll failure: ignore */ });
 		  };
 		  clearUpgradePoll();
-		  upgradePollTimer = setInterval(pollProgress, 500);
+		  const pollTimer = setInterval(pollProgress, 500);
+		  upgradePollTimer = pollTimer;
 		  pollProgress();
 		  const transcodedUrl = "/wallpaper-engine/transcoded/" + encodeURIComponent(token) + "?fps=" + cap;
 		  // Trigger + completion probe: a tiny Range request that blocks until the host
@@ -1144,12 +1171,31 @@ window.__ModuleLoader__.load({
 		  // ever held in memory and playback starts as soon as the first bytes arrive.
 		  fetch(transcodedUrl, { signal: ctrl.signal, headers: { Range: "bytes=0-0" } })
 		    .then(async (res) => {
-		      clearUpgradePoll();
-		      if (ctrl.signal.aborted) return;
-		      if (!res.ok) { selection.transcodeState = "fallback"; selection.transcodeProgress = null; emit(); return; }
+		      if (ctrl.signal.aborted) return; // superseded by a newer request
+		      if (pollTimer) clearInterval(pollTimer); // only ever this request's own timer
+		      if (!res.ok) { transcodeUpgradeFailed(video, token); return; }
 		      try { await res.arrayBuffer(); } catch { /* 1-byte body; discard */ }
 		      if (ctrl.signal.aborted) return;
-		      if (video.isConnected && selection.url && token === selection.url.split("/").pop()) {
+		      if (selection.fpsCap !== cap || !video.isConnected) {
+		        // The user changed the cap (or the wallpaper) while this request was in
+		        // flight: its output is stale. NEVER swap a stale-fps re-encode in —
+		        // drop the request state and re-decide for the CURRENT cap instead.
+		        abortTranscodeUpgrade();
+		        if (video.isConnected && selection.url && token === selection.url.split("/").pop()) {
+		          const cur = selection.fpsCap;
+		          if (cur > 0 && video.dataset.weTranscoded === String(cur)) {
+		            // Already playing exactly the requested cap (the user switched back
+		            // while this request was in flight): just settle as ready.
+		            selection.transcodeState = "ready";
+		            selection.transcodeProgress = null;
+		            emit();
+		          } else {
+		            maybeUpgradeToTranscoded(video, token);
+		          }
+		        }
+		        return;
+		      }
+		      if (selection.url && token === selection.url.split("/").pop()) {
 		        video.dataset.weTranscoded = String(cap);
 		        const t = video.currentTime;
 		        const wasPlaying = isEffectivelyPlaying();
@@ -1175,13 +1221,27 @@ window.__ModuleLoader__.load({
 		      }
 		    })
 		    .catch(() => {
-		      clearUpgradePoll();
-		      if (!ctrl.signal.aborted) {
-		        selection.transcodeState = "fallback";
-		        selection.transcodeProgress = null;
-		        emit();
-		      }
+		      if (ctrl.signal.aborted) return;
+		      if (pollTimer) clearInterval(pollTimer); // only ever this request's own timer
+		      transcodeUpgradeFailed(video, token);
 		    });
+		}
+
+		// A transcode request for the CURRENT cap failed (502 / network / encode
+		// error): the documented fallback is to play the ORIGINAL, so revert any
+		// swapped transcode (a request only ever runs when the video is on a DIFFERENT
+		// cap's transcode or the original, so this restores the honest "原片" state).
+		// The in-flight latch (upgradeToken/upgradeAbort/upgradeFps) is deliberately
+		// LEFT set: it is what stops the emit-driven syncLayers re-entry from
+		// auto-restarting a request that just failed, while a cap change / 无限制
+		// switch still clears it and allows a retry.
+		function transcodeUpgradeFailed(video, token) {
+		  if (video && video.isConnected && video.dataset.weTranscoded) {
+		    revertTranscodedVideo(video);
+		  }
+		  selection.transcodeState = "fallback";
+		  selection.transcodeProgress = null;
+		  emit();
 		}
 
 		function codecLabel(codec) {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node scripts/build-client.mjs",
-    "verify": "node scripts/verify-client.mjs",
+    "verify": "node scripts/verify-client.mjs && node scripts/verify-transcode-state.mjs",
     "prepare": "node scripts/prepare.mjs"
   },
   "peerDependencies": {

--- a/scripts/verify-transcode-state.mjs
+++ b/scripts/verify-transcode-state.mjs
@@ -1,0 +1,337 @@
+// Verify the frame-skip transcode (抽帧转码) state machine against the emitted
+// client bundle, focusing on the fps-cap switching bug:
+//
+//   switching 24→48 DIRECTLY while the 24fps transcode is still in flight used
+//   to be treated as "already working on it" — the stale 24fps request then
+//   completed, swapped the video to a 24fps re-encode and marked the state
+//   "ready" while the picker advertised the NEW cap ("已切换至 48fps 抽帧版").
+//   Only a round-trip through 无限制 (cap 0) cleared the latch, which is why
+//   that workaround "fixed" it.
+//
+// This drives the REAL bundle through apply() + the picker's onClick handlers
+// with a controllable fetch mock and asserts:
+//   1. clicking 48fps while the 24fps request is in flight ABORTS the 24fps
+//      request and starts a fresh 48fps one (no stale swap ever happens);
+//   2. the completed 48fps request swaps the video in and reports ready with
+//      the CORRECT cap;
+//   3. switching back to 24fps after the swap starts + completes a 24fps
+//      request and the state/UI stay truthful.
+//
+// Usage: node scripts/verify-transcode-state.mjs
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const results = [];
+function check(name, ok, detail) {
+  results.push({ name, ok });
+  console.log((ok ? 'PASS' : 'FAIL') + ' | ' + name + (detail ? ' | ' + detail : ''));
+}
+function assert(cond, name, detail) {
+  if (!cond) throw new Error('ASSERTION FAILED: ' + name + (detail ? ' — ' + detail : ''));
+}
+
+// ── React mock (same contract as verify-client.mjs) ─────────────────────────
+const React = {
+  Fragment: 'Fragment',
+  useState: (init) => [init, () => {}],
+  useEffect: () => {},
+  useRef: (v) => ({ current: v }),
+  createElement: (type, props, ...children) =>
+    typeof type === 'function' ? type(props || {}) : ({ type, props: props || null, children }),
+};
+
+// ── DOM mock with a real-enough <video> ─────────────────────────────────────
+let byId = {};
+const rotationTimers = [];
+function makeEl(tag) {
+  const handlers = {};
+  const el = {
+    tagName: String(tag).toUpperCase(),
+    children: [],
+    dataset: {},
+    attributes: {},
+    style: { _props: {}, setProperty(k, v) { this._props[k] = v; }, removeProperty(k) { delete this._props[k]; } },
+    className: "",
+    _parent: null,
+    appendChild(c) { c._parent = this; this.children.push(c); if (c.id) byId[c.id] = c; return c; },
+    remove() { if (this._parent) { const i = this._parent.children.indexOf(this); if (i >= 0) this._parent.children.splice(i, 1); } if (this.id) delete byId[this.id]; },
+    setAttribute(k, v) { this.attributes[k] = v; },
+    removeAttribute(k) { delete this.attributes[k]; },
+    querySelector(sel) {
+      if (sel === 'video') return this.children.find((c) => c.tagName === 'VIDEO') || null;
+      if (sel.includes('canvas')) return null;
+      return null;
+    },
+  };
+  if (String(tag).toLowerCase() === 'video') {
+    Object.assign(el, {
+      isConnected: true,
+      src: '',
+      currentTime: 0,
+      duration: 60,
+      playbackRate: 1,
+      paused: false,
+      load() { el._loadCount = (el._loadCount || 0) + 1; },
+      play() { el.paused = false; return Promise.resolve(); },
+      pause() { el.paused = true; },
+      addEventListener(type, fn, opts) { handlers[type] = fn; },
+      removeEventListener(type) { delete handlers[type]; },
+      _handlers: handlers,
+    });
+  }
+  return el;
+}
+
+const bodyEl = makeEl('body');
+const document = {
+  createElement: (t) => makeEl(t),
+  getElementById: (id) => byId[id] || null,
+  querySelector: () => null,
+  head: { appendChild: () => {} },
+  body: bodyEl,
+};
+const localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = v; },
+};
+
+// ── Controllable fetch mock ─────────────────────────────────────────────────
+// transcode requests are deferred so the test decides WHEN each completes;
+// abort wiring lets us assert the stale request actually got cancelled.
+const transcodePending = []; // { fps, url, controller, resolve, reject }
+let transcodeResolved = []; // snapshots of completed requests (fps, aborted)
+const mediaInfo = { width: 3840, height: 2160, codec: 'hvc1', fps: 120 };
+
+function wireAbort(signal, resolve, reject) {
+  if (!signal) return () => {};
+  const onAbort = () => reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }));
+  if (signal.aborted) { onAbort(); return () => {}; }
+  signal.addEventListener('abort', onAbort);
+  return () => signal.removeEventListener('abort', onAbort);
+}
+
+const fetchMock = (url, opts) => {
+  opts = opts || {};
+  if (typeof url === 'string' && url.includes('/wallpaper-engine/transcoded/')) {
+    const fps = Number(new URL(url, 'http://x').searchParams.get('fps'));
+    return new Promise((resolve, reject) => {
+      const detach = wireAbort(opts.signal, resolve, reject);
+      transcodePending.push({ fps, url, signal: opts.signal || null, resolve, reject, detach });
+    });
+  }
+  if (typeof url === 'string' && url.includes('/wallpaper-engine/transcode-progress/')) {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ phase: 'transcode', percent: 50, source: 'ffmpeg', finalizing: false, eta: 10 }) });
+  }
+  if (typeof url === 'string' && url.includes('/wallpaper-engine/media-info/')) {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, info: mediaInfo }) });
+  }
+  if (typeof url === 'string' && url.includes('/wallpaper-engine/inventory')) {
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        installDir: 'D:/we', total: 1, portableCount: 1, playlists: [],
+        wallpapers: [
+          { id: 'w1', title: 'Video W1', type: 'video', playable: true, media: '/wallpaper-engine/media/w1', preview: null, contentrating: 'Everyone' },
+        ],
+      }),
+    });
+  }
+  if (typeof url === 'string' && url.includes('/wallpaper-engine/settings')) {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+  }
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+};
+
+function activePending() {
+  return transcodePending.filter((p) => !p.signal || !p.signal.aborted);
+}
+function completeTranscode(req, ok) {
+  assert(req, 'a transcode request must be pending');
+  const i = transcodePending.indexOf(req);
+  if (i >= 0) transcodePending.splice(i, 1);
+  transcodeResolved.push({ fps: req.fps, aborted: req.signal ? req.signal.aborted : false });
+  req.detach();
+  if (ok) {
+    req.resolve({ ok: true, status: 206, arrayBuffer: () => Promise.resolve(new Uint8Array(1)) });
+  } else {
+    req.reject(Object.assign(new Error('transcode failed'), { name: 'Error' }));
+  }
+  return req;
+}
+
+// ── Module load + apply ─────────────────────────────────────────────────────
+const code = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8');
+const cap = { handoff: null };
+const sandbox = {
+  window: {
+    __ModuleLoader__: { load: (h) => { cap.handoff = h; } },
+    setTimeout: (fn, ms) => { const t = { fn, ms, cleared: false }; rotationTimers.push(t); return t; },
+    clearTimeout: (t) => { if (t) t.cleared = true; },
+    setInterval: () => ({ _interval: true }),
+    clearInterval: () => {},
+  },
+  navigator: { userAgent: 'Mozilla/5.0 Chrome/120.0' }, // non-Edge: native <video>
+  AbortController, // Node's real one: abort() must reject in-flight fetches
+  setInterval: () => ({ _interval: true }), // bare setInterval in the client
+  clearInterval: () => {},
+  document, localStorage, fetch: fetchMock, React,
+};
+vm.createContext(sandbox);
+new vm.Script(code, { filename: 'client.js' }).runInContext(sandbox);
+const { factory } = cap.handoff;
+const requireMock = (spec) => {
+  if (spec === 'react') return React;
+  if (spec === 'react-dom') return { createPortal: (node) => node };
+  throw new Error('unexpected require: ' + spec);
+};
+const exportsObj = factory(requireMock);
+
+const registrations = [];
+const pickerRenders = [];
+const slots = {
+  inject: (key, cb) => cb(),
+  register: (opts, render) => { registrations.push({ key: opts.name, id: opts.id, label: opts.label, order: opts.order }); pickerRenders.push(render); },
+};
+const effects = [];
+const ctx = { slots, effect(fn) { effects.push(fn); fn(); return fn; } };
+exportsObj.apply(ctx);
+
+// ── Tree helpers ────────────────────────────────────────────────────────────
+function walk(root, visit) {
+  if (Array.isArray(root)) { root.forEach((n) => walk(n, visit)); return; }
+  if (!root || typeof root !== 'object') return;
+  visit(root);
+  if (Array.isArray(root.children)) root.children.forEach((n) => walk(n, visit));
+}
+function findButton(tree, cls, text) {
+  let hit = null;
+  walk(tree, (n) => {
+    if (hit) return;
+    const c = typeof n.props?.className === 'string' ? n.props.className : '';
+    if (c.includes(cls) && Array.isArray(n.children) && n.children.length === 1 && n.children[0] === text) hit = n;
+  });
+  return hit;
+}
+// Wallpaper cards carry the EXACT class 'we-picker__card' (+ '--selected');
+// the close card shares that class, so ALSO require the wallpaper's title.
+function findWallpaperCard(tree, title) {
+  let hit = null;
+  walk(tree, (n) => {
+    if (hit) return;
+    const c = typeof n.props?.className === 'string' ? n.props.className : '';
+    if ((c === 'we-picker__card' || c === 'we-picker__card we-picker__card--selected') && n.props.title === title) hit = n;
+  });
+  return hit;
+}
+function renderTree() { return pickerRenders[0](); }
+
+// ── Scenario ────────────────────────────────────────────────────────────────
+async function main() {
+  // Let the initial apply() settle (inventory fetch etc.).
+  await new Promise((r) => setTimeout(r, 20));
+
+  // Open the picker modal and select the single video wallpaper.
+  let tree = renderTree();
+  const openBtn = findButton(tree, 'we-picker__btn', '选择壁纸');
+  assert(openBtn && typeof openBtn.props.onClick === 'function', 'picker open button found');
+  openBtn.props.onClick();
+  tree = renderTree();
+  const card = findWallpaperCard(tree, 'Video W1');
+  assert(card && typeof card.props.onClick === 'function', 'wallpaper card found');
+  card.props.onClick(); // applySelection('w1')
+  await new Promise((r) => setTimeout(r, 20)); // media-info probe resolves
+
+  const layer = document.getElementById('dsh-wallpaper-engine-layer');
+  assert(layer, 'wallpaper layer mounted');
+  const video = layer.querySelector('video');
+  assert(video, 'video element mounted');
+  check('wallpaper layer + video mounted', !!video);
+  check('video starts on the ORIGINAL (no transcode)', video.src === '/wallpaper-engine/media/w1' && !video.dataset.weTranscoded);
+
+  // ---- 24fps: request starts, pending ----
+  tree = renderTree();
+  const b24 = findButton(tree, 'we-picker__rate', '24fps');
+  assert(b24 && typeof b24.props.onClick === 'function', '24fps button found');
+  b24.props.onClick();
+  await new Promise((r) => setTimeout(r, 10));
+  check('click 24fps starts a transcode request', transcodePending.length === 1 && transcodePending[0].fps === 24);
+  const statusWorking = JSON.stringify(renderTree()).includes('抽帧准备中');
+  check('UI shows 抽帧准备中 while 24fps transcode runs', statusWorking);
+
+  // ---- 24 → 48 DIRECT while the 24fps request is in flight ----
+  tree = renderTree();
+  const b48 = findButton(tree, 'we-picker__rate', '48fps');
+  assert(b48 && typeof b48.props.onClick === 'function', '48fps button found');
+  b48.props.onClick();
+  await new Promise((r) => setTimeout(r, 10));
+  // The stale 24fps request must have been ABORTED, and a fresh 48fps one started.
+  const stale24 = transcodePending.find((p) => p.fps === 24);
+  check('24→48 direct: stale 24fps request is aborted (not left to swap in)',
+    transcodeResolved.length === 0 && stale24 && stale24.signal && stale24.signal.aborted === true);
+  const activeAfter48 = activePending();
+  check('24→48 direct: a fresh 48fps request starts',
+    activeAfter48.length === 1 && activeAfter48[0].fps === 48 && !activeAfter48[0].signal.aborted);
+  check('24→48 direct: video still on the ORIGINAL mid-flight', video.src === '/wallpaper-engine/media/w1' && !video.dataset.weTranscoded);
+
+  // ---- Complete the 48fps request → swap + ready with the CORRECT cap ----
+  const req48 = activeAfter48[0];
+  completeTranscode(req48, true);
+  await new Promise((r) => setTimeout(r, 20));
+  // loadedmetadata fires only after src swap; the mock fires it manually:
+  assert(video._handlers.loadedmetadata, 'loadedmetadata handler registered after swap');
+  video._handlers.loadedmetadata();
+  await new Promise((r) => setTimeout(r, 10));
+  check('48fps completes → video swapped to the 48fps re-encode',
+    video.dataset.weTranscoded === '48' && video.src.includes('fps=48'));
+  check('48fps completes → UI reports ready at 48fps',
+    JSON.stringify(renderTree()).includes('已切换至 48fps 抽帧版'));
+
+  // ---- Back to 24fps after the swap: fresh request + truthful swap ----
+  // (Regression: with the video already on a transcode, the progress poller's
+  // emit used to abort + re-start the request forever — a page freeze. The
+  // request must stay in flight across the poll emit.)
+  tree = renderTree();
+  const b24b = findButton(tree, 'we-picker__rate', '24fps');
+  b24b.props.onClick();
+  await new Promise((r) => setTimeout(r, 30)); // let several poll-emit cycles run
+  const active24b = activePending();
+  check('48→24 after swap starts a fresh 24fps request',
+    active24b.length === 1 && active24b[0].fps === 24 && !active24b[0].signal.aborted);
+  completeTranscode(active24b[0], true);
+  await new Promise((r) => setTimeout(r, 20));
+  assert(video._handlers.loadedmetadata, 'loadedmetadata handler registered (24)');
+  video._handlers.loadedmetadata();
+  await new Promise((r) => setTimeout(r, 10));
+  check('24fps completes → video swapped to the 24fps re-encode',
+    video.dataset.weTranscoded === '24' && video.src.includes('fps=24'));
+  check('24fps completes → UI reports ready at 24fps',
+    JSON.stringify(renderTree()).includes('已切换至 24fps 抽帧版'));
+
+  // ---- 无限制 clears everything (the historical workaround, still works) ----
+  tree = renderTree();
+  const b0 = findButton(tree, 'we-picker__rate', '无限制');
+  assert(b0 && typeof b0.props.onClick === 'function', '无限制 button found');
+  b0.props.onClick();
+  await new Promise((r) => setTimeout(r, 10));
+  check('无限制 reverts to the original + idle', !video.dataset.weTranscoded && video.src === '/wallpaper-engine/media/w1');
+
+  // ---- Failure of a NEW cap reverts to the original (truthful 已回退原片) ----
+  b24b.props.onClick();
+  await new Promise((r) => setTimeout(r, 10));
+  completeTranscode(activePending()[0], false); // 502/network failure
+  await new Promise((r) => setTimeout(r, 20));
+  check('failed transcode → video back on the original',
+    !video.dataset.weTranscoded && video.src === '/wallpaper-engine/media/w1');
+  check('failed transcode → UI reports fallback',
+    JSON.stringify(renderTree()).includes('转码不可用，已回退原片'));
+
+  const failed = results.filter((r) => !r.ok);
+  console.log('\n' + (failed.length === 0 ? 'ALL TRANSCODE STATE CHECKS PASSED' : failed.length + ' CHECK(S) FAILED'));
+  process.exit(failed.length === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('TEST ERROR:', err && err.stack ? err.stack : err);
+  process.exit(1);
+});

--- a/src/client.js
+++ b/src/client.js
@@ -1216,6 +1216,13 @@ function maybeUpgradeToTranscoded(video, token) {
           } else {
             maybeUpgradeToTranscoded(video, token);
           }
+        } else {
+          // The layer/video was rebuilt while this request was in flight (e.g.
+          // Edge 兼容 render-mode toggle, or a wallpaper switch that raced the
+          // abort): re-run syncLayers so the CURRENT video gets its own fresh
+          // upgrade decision — otherwise it would sit on the original (full
+          // decode) until some unrelated emit happened to re-trigger it.
+          emit();
         }
         return;
       }

--- a/src/client.js
+++ b/src/client.js
@@ -739,6 +739,10 @@ function applySelection(id) {
   // Keep the preview around so a failed static frame can fall back to it.
   selection.previewUrl = w.preview || null;
   selection.transcodeState = "idle";
+  // The previous wallpaper's media info must not leak into the new one: a stale
+  // fps would make the sync "源帧率 ≤ 上限" check wrongly skip the transcode
+  // (and the UI would keep claiming 无需抽帧 for a 120fps source).
+  selection.mediaInfo = null;
   abortTranscodeUpgrade();
   refreshMediaInfo();
   syncRotationTimer();
@@ -1075,6 +1079,11 @@ async function refreshMediaInfo(force) {
       const mi = selection.mediaInfo;
       if (mi && mi.fps && mi.fps > 0 && selection.fpsCap > 0 && mi.fps <= selection.fpsCap) {
         abortTranscodeUpgrade();
+        // Also drop a swapped transcode from a previous LOWER cap, so the
+        // "无需抽帧" hint matches what is actually playing (the original).
+        const layer = document.getElementById(LAYER_ID);
+        const video = layer && layer.querySelector("video");
+        if (video && video.dataset.weTranscoded) revertTranscodedVideo(video);
         selection.transcodeState = "skipped";
       }
       emit();
@@ -1086,6 +1095,13 @@ async function refreshMediaInfo(force) {
 
 let upgradeAbort = null;
 let upgradeToken = "";
+// The fps cap the in-flight upgrade request targets (0 = none). The in-flight
+// latch is keyed by token ONLY in the old code, so switching 24→48 while the
+// 24fps transcode was still running was treated as "already working on it" —
+// the stale 24fps request then completed and swapped the video to a 24fps
+// re-encode while the picker advertised the new cap ("已切换至 48fps 抽帧版").
+// Tracking the cap lets a cap change abort the stale request and start fresh.
+let upgradeFps = 0;
 let upgradePollTimer = null; // progress poller while the transcode fetch pends
 function clearUpgradePoll() {
   if (upgradePollTimer) { clearInterval(upgradePollTimer); upgradePollTimer = null; }
@@ -1094,6 +1110,7 @@ function abortTranscodeUpgrade() {
   clearUpgradePoll();
   if (upgradeAbort) { upgradeAbort.abort(); upgradeAbort = null; }
   upgradeToken = "";
+  upgradeFps = 0;
   selection.transcodeProgress = null;
 }
 // Revert a video that was swapped to a capped-fps transcode back to the source.
@@ -1127,15 +1144,24 @@ function maybeUpgradeToTranscoded(video, token) {
     return;
   }
   if (video.dataset.weTranscoded === String(cap)) return; // already on this cap
-  if (!video.dataset.weTranscoded && upgradeToken === token && upgradeAbort) return; // working on it
+  // Only an in-flight request for THIS cap counts as "working on it": a request
+  // for a different cap would complete and swap in a stale-fps re-encode while
+  // the picker advertises the current cap (24→48 direct switch bug). The guard
+  // is deliberately NOT conditioned on weTranscoded: the progress poller emits
+  // (→ syncLayers → this function), and with the video already on a transcode
+  // that emit used to abort + re-start the request forever (page freeze).
+  if (upgradeToken === token && upgradeAbort && upgradeFps === cap) return; // already working on this cap
   abortTranscodeUpgrade();
   upgradeToken = token;
+  upgradeFps = cap;
   const ctrl = new AbortController();
   upgradeAbort = ctrl;
   selection.transcodeState = "working";
   selection.transcodeProgress = null;
   // Progress poller: 500ms interval reading /transcode-progress (download %,
-  // then frame-based transcode % + ETA). Cleared on settle/abort.
+  // then frame-based transcode % + ETA). Cleared on settle/abort. The timer is
+  // ALSO kept in this closure so THIS request's completion only ever clears its
+  // OWN timer — a stale request must not kill the newer request's poller.
   const pollProgress = () => {
     if (ctrl.signal.aborted) return;
     fetch("/wallpaper-engine/transcode-progress/" + encodeURIComponent(token) + "?fps=" + cap, { cache: "no-store" })
@@ -1159,7 +1185,8 @@ function maybeUpgradeToTranscoded(video, token) {
       .catch(() => { /* transient poll failure: ignore */ });
   };
   clearUpgradePoll();
-  upgradePollTimer = setInterval(pollProgress, 500);
+  const pollTimer = setInterval(pollProgress, 500);
+  upgradePollTimer = pollTimer;
   pollProgress();
   const transcodedUrl = "/wallpaper-engine/transcoded/" + encodeURIComponent(token) + "?fps=" + cap;
   // Trigger + completion probe: a tiny Range request that blocks until the host
@@ -1168,12 +1195,31 @@ function maybeUpgradeToTranscoded(video, token) {
   // ever held in memory and playback starts as soon as the first bytes arrive.
   fetch(transcodedUrl, { signal: ctrl.signal, headers: { Range: "bytes=0-0" } })
     .then(async (res) => {
-      clearUpgradePoll();
-      if (ctrl.signal.aborted) return;
-      if (!res.ok) { selection.transcodeState = "fallback"; selection.transcodeProgress = null; emit(); return; }
+      if (ctrl.signal.aborted) return; // superseded by a newer request
+      if (pollTimer) clearInterval(pollTimer); // only ever this request's own timer
+      if (!res.ok) { transcodeUpgradeFailed(video, token); return; }
       try { await res.arrayBuffer(); } catch { /* 1-byte body; discard */ }
       if (ctrl.signal.aborted) return;
-      if (video.isConnected && selection.url && token === selection.url.split("/").pop()) {
+      if (selection.fpsCap !== cap || !video.isConnected) {
+        // The user changed the cap (or the wallpaper) while this request was in
+        // flight: its output is stale. NEVER swap a stale-fps re-encode in —
+        // drop the request state and re-decide for the CURRENT cap instead.
+        abortTranscodeUpgrade();
+        if (video.isConnected && selection.url && token === selection.url.split("/").pop()) {
+          const cur = selection.fpsCap;
+          if (cur > 0 && video.dataset.weTranscoded === String(cur)) {
+            // Already playing exactly the requested cap (the user switched back
+            // while this request was in flight): just settle as ready.
+            selection.transcodeState = "ready";
+            selection.transcodeProgress = null;
+            emit();
+          } else {
+            maybeUpgradeToTranscoded(video, token);
+          }
+        }
+        return;
+      }
+      if (selection.url && token === selection.url.split("/").pop()) {
         video.dataset.weTranscoded = String(cap);
         const t = video.currentTime;
         const wasPlaying = isEffectivelyPlaying();
@@ -1199,13 +1245,27 @@ function maybeUpgradeToTranscoded(video, token) {
       }
     })
     .catch(() => {
-      clearUpgradePoll();
-      if (!ctrl.signal.aborted) {
-        selection.transcodeState = "fallback";
-        selection.transcodeProgress = null;
-        emit();
-      }
+      if (ctrl.signal.aborted) return;
+      if (pollTimer) clearInterval(pollTimer); // only ever this request's own timer
+      transcodeUpgradeFailed(video, token);
     });
+}
+
+// A transcode request for the CURRENT cap failed (502 / network / encode
+// error): the documented fallback is to play the ORIGINAL, so revert any
+// swapped transcode (a request only ever runs when the video is on a DIFFERENT
+// cap's transcode or the original, so this restores the honest "原片" state).
+// The in-flight latch (upgradeToken/upgradeAbort/upgradeFps) is deliberately
+// LEFT set: it is what stops the emit-driven syncLayers re-entry from
+// auto-restarting a request that just failed, while a cap change / 无限制
+// switch still clears it and allows a retry.
+function transcodeUpgradeFailed(video, token) {
+  if (video && video.isConnected && video.dataset.weTranscoded) {
+    revertTranscodedVideo(video);
+  }
+  selection.transcodeState = "fallback";
+  selection.transcodeProgress = null;
+  emit();
 }
 
 function codecLabel(codec) {


### PR DESCRIPTION
## 问题描述

「帧率上限」在不同档位之间**直接**切换（例如 24fps → 48fps）存在 bug：如果旧帧率的转码还在进行中，这次切换会被当作「已经在处理」而跳过；随后旧请求完成，把视频换成了**旧帧率的抽帧版**，而配置 UI 却显示「已切换至 48fps 抽帧版」——界面与实际播放不一致。只有先切到「无限制」再切换才正常，因为 cap=0 会清空整个在途状态。

## 根因

`maybeUpgradeToTranscoded` 的「在途请求」守卫只按壁纸 token 判断，不区分目标帧率：

- `if (!video.dataset.weTranscoded && upgradeToken === token && upgradeAbort) return` 把同一壁纸的任何在途请求都当成「正在处理当前帧率」。切换帧率后旧请求继续跑，完成后就把错误的帧率换进视频；
- 该守卫里的 `!weTranscoded` 条件还会让进度轮询的 `emit()`（→ syncLayers → maybeUpgradeToTranscoded）在视频已经处于某个抽帧版时反复 abort / 重启请求，**页面直接卡死**。

## 改动

- 记录在途请求的目标帧率（`upgradeFps`）：只有帧率匹配时才视为「正在处理该帧率」，否则中止旧请求、立即按新帧率重新发起；
- 守卫去掉 `!weTranscoded` 条件（修复轮询 emit 导致的无限重启 / 卡死）；
- 请求完成时校验 `selection.fpsCap === cap`：过期的转码产物**绝不换入**，改为按当前帧率重新决策（若视频已经正好播放当前帧率，则直接置为 ready，不再多跑一次转码）；
- 轮询定时器改为闭包持有：过期请求不会误清掉新请求的进度轮询；
- 转码失败时回退到原片（与文档「已回退原片」的语义一致），并保留在途锁，避免失败后被 emit 驱动的重入自动重试成风暴；
- 切换壁纸时清空上一张壁纸的 `mediaInfo`（旧壁纸的帧率会把新壁纸误判成「源帧率 ≤ 上限，无需抽帧」）；源帧率 ≤ 上限时同步回退旧的抽帧版，保证文案与实际播放一致。

## 测试

新增 `scripts/verify-transcode-state.mjs`：VM 回归测试，用可控的 fetch mock 驱动真实 bundle 走完整 UI 流程，断言「24fps 转码进行中直接切 48fps」会中止过期请求、换入正确帧率、且所有状态与 UI 文案始终一致（15 项断言，含转码失败回退、无限制回退等场景）。`npm run verify` 现在同时跑两个验证器。

## 验证步骤

1. `npm run build && npm run verify`；
2. 选一个 >48fps 的视频壁纸，先点 24fps，**趁转码还在进行**直接点 48fps——旧 24fps 请求被中止、立即发起 48fps 请求，状态文案不会出现「已切换至 48fps」而实际播放 24fps 的情况；
3. 转码完成后在 48fps ↔ 24fps 之间来回切换——不再卡死，UI 与实际播放始终一致。