### PR TITLE
feat: 侧栏液态玻璃细粒度控制 + better-sidebar 安装检测

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -104,6 +104,16 @@ window.__ModuleLoader__.load({
 		  glassAlpha: 12,
 		  glassColor: "#ffffff",
 		  glassWindow: true,
+		  // dsh-better-sidebar 液态玻璃：与设置窗口玻璃同级的一套「细节自由」控制，
+		  // 独立于会话玻璃（玻璃 / 玻璃透明度）——侧栏想多透 / 多糊 / 换个底色都行：
+		  // - sidebarGlass：总开关，关闭后侧栏恢复原生外观（不再透明 / 不再模糊）；
+		  // - sidebarBlur：侧栏专用 backdrop 模糊半径（px，0 = 关闭毛玻璃）；
+		  // - sidebarAlpha：侧栏玻璃透明度（%），语义与玻璃透明度一致（越大越透）；
+		  // - sidebarColor：侧栏玻璃基底色调（#rrggbb），默认白色，双主题统一生效。
+		  sidebarGlass: true,
+		  sidebarBlur: 16,
+		  sidebarAlpha: 12,
+		  sidebarColor: "#ffffff",
 		};
 
 		// Selectable values for the two filters. Declared up top because
@@ -204,6 +214,11 @@ window.__ModuleLoader__.load({
 		    glassColor: typeof o.glassColor === "string" && /^#[0-9a-f]{6}$/i.test(o.glassColor)
 		      ? o.glassColor : DEFAULTS.glassColor,
 		    glassWindow: o.glassWindow !== false,
+		    sidebarGlass: o.sidebarGlass !== false,
+		    sidebarBlur: clampNum(o.sidebarBlur, 0, 60, DEFAULTS.sidebarBlur),
+		    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, DEFAULTS.sidebarAlpha),
+		    sidebarColor: typeof o.sidebarColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
+		      ? o.sidebarColor : DEFAULTS.sidebarColor,
 		  };
 		}
 
@@ -226,6 +241,11 @@ window.__ModuleLoader__.load({
 		  // Transient: source media metadata ({ width, height, codec, fps }) from
 		  // /media-info (host moov probe, cached).
 		  mediaInfo: null,
+		  // Transient: whether dsh-better-sidebar is installed & enabled (host reports
+		  // it via the settings GET response). Gates the 侧栏玻璃 control group in the
+		  // picker — the knobs are meaningless without the sidebar, so they only show
+		  // when it is actually there.
+		  sidebarPresent: false,
 		  // Transient: 抽帧转码 lifecycle — "idle" | "working" | "ready" | "fallback"
 		  // | "skipped" (see maybeUpgradeToTranscoded).
 		  transcodeState: "idle",
@@ -301,6 +321,10 @@ window.__ModuleLoader__.load({
 		    glassAlpha: selection.glassAlpha,
 		    glassColor: selection.glassColor,
 		    glassWindow: selection.glassWindow,
+		    sidebarGlass: selection.sidebarGlass,
+		    sidebarBlur: selection.sidebarBlur,
+		    sidebarAlpha: selection.sidebarAlpha,
+		    sidebarColor: selection.sidebarColor,
 		  };
 		}
 
@@ -363,6 +387,8 @@ window.__ModuleLoader__.load({
 		    if (res.ok) {
 		      const data = await res.json();
 		      hostSettings = data && data.settings;
+		      // 侧栏玻璃控制组只在 dsh-better-sidebar 已安装且启用时显示（host 检测）。
+		      selection.sidebarPresent = !!(data && data.betterSidebar);
 		      hostOk = true;
 		    }
 		  } catch { /* host unreachable */ }
@@ -1302,6 +1328,17 @@ window.__ModuleLoader__.load({
 		  if (selection.glassWindow) document.body.setAttribute("data-we-glass-window", "on");
 		  else document.body.removeAttribute("data-we-glass-window");
 
+		  // dsh-better-sidebar 液态玻璃：一套独立于会话玻璃的细粒度控制（侧栏模糊 /
+		  // 侧栏透明度 / 侧栏玻璃颜色 + 总开关）。变量只作用于 [data-dsh-better-sidebar]
+		  // 子树（CSS 见下），关闭总开关时侧栏恢复原生外观。
+		  s.setProperty("--we-sidebar-blur", selection.sidebarBlur + "px");
+		  s.setProperty("--we-sidebar-saturate", String(1.15 + selection.sidebarBlur * 0.028));
+		  const sidebarAlpha = Math.max(0.03, 0.25 - (selection.sidebarAlpha / 60) * 0.22);
+		  s.setProperty("--we-sidebar-alpha", String(sidebarAlpha));
+		  s.setProperty("--we-sidebar-color", selection.sidebarColor);
+		  if (selection.sidebarGlass) document.body.setAttribute("data-we-sidebar-glass", "on");
+		  else document.body.removeAttribute("data-we-sidebar-glass");
+
 		  // Scrim immediacy: some composited/kiosk environments do not repaint a
 		  // z-index:-1 layer promptly when only an inherited CSS variable changes.
 		  // Write the resolved color DIRECTLY onto the scrim element's inline style and
@@ -1332,6 +1369,11 @@ window.__ModuleLoader__.load({
 		  s.removeProperty("--we-glass-alpha");
 		  s.removeProperty("--we-glass-color");
 		  document.body.removeAttribute("data-we-glass-window");
+		  s.removeProperty("--we-sidebar-blur");
+		  s.removeProperty("--we-sidebar-saturate");
+		  s.removeProperty("--we-sidebar-alpha");
+		  s.removeProperty("--we-sidebar-color");
+		  document.body.removeAttribute("data-we-sidebar-glass");
 		  const scrim = document.getElementById(SCRIM_ID);
 		  if (scrim) scrim.style.background = "";
 		}
@@ -1486,6 +1528,21 @@ window.__ModuleLoader__.load({
 		  };
 		  const onGlassAlpha = (pct) => {
 		    selection.glassAlpha = clampNum(pct, 0, 60, DEFAULTS.glassAlpha);
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  // 侧栏玻璃（dsh-better-sidebar）：独立于会话玻璃的一套细粒度控制，各自立即
+		  // 生效并持久化（--we-sidebar-blur / --we-sidebar-alpha / --we-sidebar-color）。
+		  const onSidebarBlur = (px) => {
+		    selection.sidebarBlur = clampNum(px, 0, 60, DEFAULTS.sidebarBlur);
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  const onSidebarAlpha = (pct) => {
+		    selection.sidebarAlpha = clampNum(pct, 0, 60, DEFAULTS.sidebarAlpha);
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  const onSidebarColor = (hex) => {
+		    if (!/^#[0-9a-f]{6}$/i.test(hex)) return;
+		    selection.sidebarColor = hex;
 		    persistSelection(); applyEffects(); emit();
 		  };
 
@@ -1659,6 +1716,57 @@ window.__ModuleLoader__.load({
 		      React.createElement("span", { className: "we-picker__hint" },
 		        "整个设置窗口（含 General / 模型 / 插件等全部原生分区）跟随配色与透明度；关闭则恢复原生样式",
 		      ),
+		      // 侧栏玻璃（dsh-better-sidebar 适配）：与设置窗口玻璃同级的一套独立细粒度
+		      // 控制 —— 总开关 + 专用模糊 + 专用透明度 + 玻璃基底色调，全部只作用于
+		      // dsh-better-sidebar 子树，不动会话玻璃（玻璃 / 玻璃透明度）的设置。
+		      // 仅在 host 检测到 dsh-better-sidebar 已安装且启用时显示（sidebarPresent）。
+		      // 开关本体 + 说明始终显示；三个细节滑块（侧栏模糊 / 侧栏透明度 / 侧栏玻璃
+		      // 颜色）以「侧栏液态玻璃」开关为前提 —— 关闭时隐藏，开启后随 emit 重渲染
+		      // 实时出现（滑块只在毛玻璃生效时有意义）。
+		      sel.sidebarPresent && [
+		      React.createElement("label", { className: "we-picker__rotation-toggle we-picker__window-toggle" },
+		        React.createElement("input", {
+		          type: "checkbox",
+		          checked: sel.sidebarGlass,
+		          onChange: (e) => {
+		            selection.sidebarGlass = e.target.checked;
+		            persistSelection();
+		            applyEffects();
+		            emit();
+		          },
+		        }),
+		        "侧栏液态玻璃",
+		      ),
+		      React.createElement("span", { className: "we-picker__hint" },
+		        "dsh-better-sidebar 侧栏（文件 / 终端 / Git 等面板）的毛玻璃适配；关闭则恢复其原生外观",
+		      ),
+		      ],
+		      sel.sidebarPresent && sel.sidebarGlass && [
+		      SliderRow("侧栏模糊", 0, 60, 1, sel.sidebarBlur, onSidebarBlur, sel.sidebarBlur + "px"),
+		      SliderRow("侧栏透明度", 0, 60, 5, sel.sidebarAlpha, onSidebarAlpha, sel.sidebarAlpha + "%"),
+		      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+		        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "侧栏玻璃颜色"),
+		        GLASS_COLOR_PRESETS.map((hex) => React.createElement("button", {
+		          key: hex,
+		          className: "we-picker__swatch" + (sel.sidebarColor === hex ? " we-picker__swatch--active" : ""),
+		          type: "button",
+		          style: { background: hex },
+		          title: hex,
+		          onClick: () => onSidebarColor(hex),
+		          "aria-label": "侧栏玻璃颜色 " + hex,
+		        })),
+		        React.createElement("label", { className: "we-picker__swatch-custom" },
+		          React.createElement("input", {
+		            type: "color",
+		            value: sel.sidebarColor,
+		            onInput: (e) => onSidebarColor(e.target.value),
+		            onChange: (e) => onSidebarColor(e.target.value),
+		            title: "自定义侧栏玻璃颜色",
+		          }),
+		          React.createElement("span", { className: "we-picker__hint" }, "自定义"),
+		        ),
+		      ),
+		      ],
 		    ),
 		    // ── Card-style switch: classic (WE's original aspect-ratio 16/9 cards —
 		    //    the CD-like look the author liked) vs the rewritten fixed-height
@@ -2459,44 +2567,69 @@ window.__ModuleLoader__.load({
 		     target the whole tree without depending on its CSS-module hashes. Its root
 		     panels read the opaque --dsw-alias-bg-layer-1 token (hence the "black
 		     frame") — give them the SAME clear liquid-glass recipe as the
-		     composer/bubbles (faint specular sheen + gentle frosted melt), with blur
-		     radius + saturation driven by the 玻璃 slider (--we-blur / --we-saturate).
+		     composer/bubbles (faint specular sheen + gentle frosted melt).
+		     Unlike the conversation surfaces, the sidebar glass is FULLY independent:
+		     the master switch body[data-we-sidebar-glass] (侧栏液态玻璃) gates the whole
+		     adaptation, and blur / saturation / transparency / base tint each have
+		     their own knob (--we-sidebar-blur / --we-sidebar-saturate /
+		     --we-sidebar-alpha / --we-sidebar-color, from 侧栏模糊 / 侧栏透明度 /
+		     侧栏玻璃颜色), so the sidebar can be blurrier, clearer, more transparent
+		     or tinted however you like without touching the 玻璃 / 玻璃透明度 sliders.
 		     Inner chrome surfaces that paint the same opaque tokens get a translucent
 		     base too; the blur lives on the root panels (one blur per shell). */
-		  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
-		  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
-		    background-color: rgba(255, 255, 255, calc(var(--we-glass-alpha, 0.15) * 0.66)) !important;
+		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
+		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
+		    background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.66 * 100%), transparent) !important;
 		    background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.04) 38%, rgba(255, 255, 255, 0.01)) !important;
-		    -webkit-backdrop-filter: blur(var(--we-blur, 16px)) saturate(var(--we-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
-		    backdrop-filter: blur(var(--we-blur, 16px)) saturate(var(--we-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
+		    -webkit-backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
+		    backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
 		    box-shadow:
 		      inset 0 1px 0 rgba(255, 255, 255, var(--we-glass-highlight, 0.32)),
 		      inset 0 -1px 0 rgba(255, 255, 255, 0.08),
 		      inset 0 0 0 0.5px rgba(255, 255, 255, 0.06);
 		  }
-		  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
-		  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],
-		  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_paneCard"],
-		  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_editorHeader"],
-		  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_explorerHeader"],
-		  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_gitHeader"],
-		  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_browserBar"],
-		  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_terminalWrap"] {
-		    background-color: rgba(255, 255, 255, calc(var(--we-glass-alpha, 0.15) * 0.53)) !important;
+		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
+		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],
+		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_paneCard"],
+		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_editorHeader"],
+		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_explorerHeader"],
+		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_gitHeader"],
+		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_browserBar"],
+		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_terminalWrap"] {
+		    background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.53 * 100%), transparent) !important;
 		  }
-		  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
-		  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
-		    background-color: rgba(255, 255, 255, calc(var(--we-glass-alpha, 0.15) * 0.33)) !important;
+		  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
+		  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
+		    background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.33 * 100%), transparent) !important;
 		  }
-		  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
-		  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],
-		  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_paneCard"],
-		  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_editorHeader"],
-		  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_explorerHeader"],
-		  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_gitHeader"],
-		  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_browserBar"],
-		  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_terminalWrap"] {
-		    background-color: rgba(255, 255, 255, calc(var(--we-glass-alpha, 0.15) * 0.26)) !important;
+		  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
+		  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],
+		  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_paneCard"],
+		  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_editorHeader"],
+		  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_explorerHeader"],
+		  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_gitHeader"],
+		  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_browserBar"],
+		  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_terminalWrap"] {
+		    background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.26 * 100%), transparent) !important;
+		  }
+		  /* No backdrop-filter support: fall back to near-opaque tinted surfaces so
+		     sidebar text never sits directly on a busy wallpaper (same policy as the
+		     settings-window glass). The tint still applies. */
+		  @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+		    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
+		    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"],
+		    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
+		    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],
+		    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_paneCard"],
+		    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_editorHeader"],
+		    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_explorerHeader"],
+		    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_gitHeader"],
+		    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_browserBar"],
+		    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_terminalWrap"] {
+		      background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) 92%, transparent) !important;
+		      backdrop-filter: none !important;
+		      -webkit-backdrop-filter: none !important;
+		    }
 		  }
 
 		  /* Picker chrome. */

--- a/lib/index.js
+++ b/lib/index.js
@@ -457,6 +457,29 @@ function clampStr(v, allowed, fallback) {
   return allowed.includes(v) ? v : fallback;
 }
 
+// dsh-better-sidebar 安装检测：遍历 cordis loader 的条目树（ctx.loader 是根
+// EntryTree，entries() 覆盖所有嵌套子树），找 dsh-better-sidebar 且未禁用的
+// 条目。用它决定浏览器端的「侧栏玻璃」控制组是否显示 —— 不依赖侧栏 DOM 是否
+// 已挂载（侧栏懒加载，DOM 探测会漏判），也不依赖其服务 API（版本间不稳定）。
+// 注意 Entry 本身没有 name getter：包名在 entry.options.name（patch 行的 name
+// 字段，即 import 说明符）；聚合包挂载时条目 id 可能是 web-ui-better-sidebar
+// 之类，故 id 含 better-sidebar 也视为命中。loader 服务随 dsh-base 提供，
+// 读不到时按「未安装」处理。
+function isBetterSidebarLoaded(ctx) {
+  try {
+    const loader = ctx && ctx.loader;
+    if (!loader || typeof loader.entries !== 'function') return false;
+    for (const entry of loader.entries()) {
+      const opts = entry && entry.options;
+      if (!opts || opts.group) continue; // group 节点跳过
+      const isSidebar = opts.name === 'dsh-better-sidebar'
+        || String(opts.id || '').includes('better-sidebar');
+      if (isSidebar && !entry.disabled) return true;
+    }
+  } catch { /* loader unavailable (headless/embed contexts): treat as absent */ }
+  return false;
+}
+
 function sanitizeSettings(raw) {
   if (!raw || typeof raw !== 'object') return null;
   const o = raw;
@@ -503,6 +526,12 @@ function sanitizeSettings(raw) {
     glassColor: typeof o.glassColor === 'string' && /^#[0-9a-f]{6}$/i.test(o.glassColor)
       ? o.glassColor : '#ffffff',
     glassWindow: o.glassWindow !== false,
+    // dsh-better-sidebar glass knobs (mirror of src/client.js).
+    sidebarGlass: o.sidebarGlass !== false,
+    sidebarBlur: clampNum(o.sidebarBlur, 0, 60, 16),
+    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, 12),
+    sidebarColor: typeof o.sidebarColor === 'string' && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
+      ? o.sidebarColor : '#ffffff',
   };
 }
 
@@ -1858,7 +1887,9 @@ export function apply(ctx) {
         res.end(JSON.stringify(payload));
       };
       if (method === 'GET') {
-        json(200, { settings: readSettings() });
+        // betterSidebar: 侧栏玻璃控制组是否显示（dsh-better-sidebar 已安装且
+        // 启用）。挂在 settings 响应上，客户端 loadPersisted 时一次取回。
+        json(200, { settings: readSettings(), betterSidebar: isBetterSidebarLoaded(ctx) });
         return;
       }
       if (method !== 'PUT') {

--- a/scripts/verify-client.mjs
+++ b/scripts/verify-client.mjs
@@ -59,7 +59,15 @@ const localStorage = {
   getItem(k) { return this._store[k] ?? null; },
   setItem(k, v) { this._store[k] = v; },
 };
-const fetch = () => Promise.resolve({
+const fetch = (url) => {
+  // Route the settings GET: host reports dsh-better-sidebar as installed +
+  // enabled (→ the 侧栏玻璃 control group must render), while keeping settings
+  // empty so loadPersisted takes the "host has nothing yet → migrate the
+  // localStorage seed" path the rest of the harness relies on.
+  if (String(url).includes('/wallpaper-engine/settings')) {
+    return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ ok: true, betterSidebar: true }) });
+  }
+  return Promise.resolve({
   ok: true, status: 200,
   json: () => Promise.resolve({
     installDir: "D:/we", total: 34, portableCount: 33,
@@ -82,7 +90,8 @@ const fetch = () => Promise.resolve({
       { id: "e", title: "PG13 E", type: "web", playable: true, media: "/wallpaper-engine/media/pg", preview: null, contentrating: "PG13" },
     ],
   }),
-});
+  });
+};
 
 const code = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8');
 const cap = { handoff: null };
@@ -182,6 +191,42 @@ setTimeout(() => {
       console.log('glass color custom input present:', treeText.includes('自定义玻璃颜色'));
       console.log('custom color input present:', treeText.includes('type":"color"'));
       console.log('glass transparency slider row present:', treeText.includes('玻璃透明度'));
+      console.log('sidebar-glass master switch present:', treeText.includes('侧栏液态玻璃'));
+      console.log('sidebar blur slider present:', treeText.includes('侧栏模糊'));
+      console.log('sidebar alpha slider present:', treeText.includes('侧栏透明度'));
+      console.log('sidebar glass-color swatches (expect 6):', (treeText.match(/"aria-label":"侧栏玻璃颜色 /g) || []).length);
+      console.log('sidebar glass color custom input present:', treeText.includes('自定义侧栏玻璃颜色'));
+      // The three detail knobs (侧栏模糊 / 侧栏透明度 / 侧栏玻璃颜色) are
+      // conditional on the 侧栏液态玻璃 master switch: off → hidden, on →
+      // restored, in the SAME render pass (the toggle re-emits synchronously).
+      const sidebarSwitch = (() => {
+        let hit = null;
+        (function walk(node) {
+          if (Array.isArray(node)) { node.forEach(walk); return; }
+          if (!node || typeof node !== 'object') return;
+          const children = Array.isArray(node.children) ? node.children : [];
+          if (children.includes('侧栏液态玻璃')) {
+            const input = children.find((c) => c && typeof c === 'object' && c.type === 'input');
+            if (input && typeof input.props.onChange === 'function') hit = input;
+          }
+          if (Array.isArray(node.children)) node.children.forEach(walk);
+        })(tree);
+        return hit;
+      })();
+      if (sidebarSwitch) {
+        sidebarSwitch.props.onChange({ target: { checked: false } });
+        tree = pickerRenders[0]();
+        const offText = JSON.stringify(tree);
+        console.log('switch off hides the three detail knobs:',
+          !offText.includes('侧栏模糊') && !offText.includes('侧栏透明度') && !offText.includes('侧栏玻璃颜色'));
+        console.log('switch itself stays visible when off:', offText.includes('侧栏液态玻璃'));
+        sidebarSwitch.props.onChange({ target: { checked: true } });
+        tree = pickerRenders[0]();
+        console.log('switch back on restores the detail knobs:',
+          JSON.stringify(tree).includes('侧栏模糊') && JSON.stringify(tree).includes('侧栏透明度') && JSON.stringify(tree).includes('侧栏玻璃颜色'));
+      } else {
+        console.log('switch off hides the three detail knobs: false (switch not found)');
+      }
       // 玻璃 slider now spans 0–60 px (was 0–40): assert the raised max on the
       // 玻璃 range input (label "玻璃", max 60) so the range stays in sync.
       const glassSlider = (() => {

--- a/src/client.js
+++ b/src/client.js
@@ -128,6 +128,16 @@ const DEFAULTS = {
   glassAlpha: 12,
   glassColor: "#ffffff",
   glassWindow: true,
+  // dsh-better-sidebar 液态玻璃：与设置窗口玻璃同级的一套「细节自由」控制，
+  // 独立于会话玻璃（玻璃 / 玻璃透明度）——侧栏想多透 / 多糊 / 换个底色都行：
+  // - sidebarGlass：总开关，关闭后侧栏恢复原生外观（不再透明 / 不再模糊）；
+  // - sidebarBlur：侧栏专用 backdrop 模糊半径（px，0 = 关闭毛玻璃）；
+  // - sidebarAlpha：侧栏玻璃透明度（%），语义与玻璃透明度一致（越大越透）；
+  // - sidebarColor：侧栏玻璃基底色调（#rrggbb），默认白色，双主题统一生效。
+  sidebarGlass: true,
+  sidebarBlur: 16,
+  sidebarAlpha: 12,
+  sidebarColor: "#ffffff",
 };
 
 // Selectable values for the two filters. Declared up top because
@@ -228,6 +238,11 @@ function sanitizeSettings(o) {
     glassColor: typeof o.glassColor === "string" && /^#[0-9a-f]{6}$/i.test(o.glassColor)
       ? o.glassColor : DEFAULTS.glassColor,
     glassWindow: o.glassWindow !== false,
+    sidebarGlass: o.sidebarGlass !== false,
+    sidebarBlur: clampNum(o.sidebarBlur, 0, 60, DEFAULTS.sidebarBlur),
+    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, DEFAULTS.sidebarAlpha),
+    sidebarColor: typeof o.sidebarColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
+      ? o.sidebarColor : DEFAULTS.sidebarColor,
   };
 }
 
@@ -250,6 +265,11 @@ const selection = {
   // Transient: source media metadata ({ width, height, codec, fps }) from
   // /media-info (host moov probe, cached).
   mediaInfo: null,
+  // Transient: whether dsh-better-sidebar is installed & enabled (host reports
+  // it via the settings GET response). Gates the 侧栏玻璃 control group in the
+  // picker — the knobs are meaningless without the sidebar, so they only show
+  // when it is actually there.
+  sidebarPresent: false,
   // Transient: 抽帧转码 lifecycle — "idle" | "working" | "ready" | "fallback"
   // | "skipped" (see maybeUpgradeToTranscoded).
   transcodeState: "idle",
@@ -325,6 +345,10 @@ function serializeSelection() {
     glassAlpha: selection.glassAlpha,
     glassColor: selection.glassColor,
     glassWindow: selection.glassWindow,
+    sidebarGlass: selection.sidebarGlass,
+    sidebarBlur: selection.sidebarBlur,
+    sidebarAlpha: selection.sidebarAlpha,
+    sidebarColor: selection.sidebarColor,
   };
 }
 
@@ -387,6 +411,8 @@ async function loadPersisted() {
     if (res.ok) {
       const data = await res.json();
       hostSettings = data && data.settings;
+      // 侧栏玻璃控制组只在 dsh-better-sidebar 已安装且启用时显示（host 检测）。
+      selection.sidebarPresent = !!(data && data.betterSidebar);
       hostOk = true;
     }
   } catch { /* host unreachable */ }
@@ -1326,6 +1352,17 @@ function applyEffects() {
   if (selection.glassWindow) document.body.setAttribute("data-we-glass-window", "on");
   else document.body.removeAttribute("data-we-glass-window");
 
+  // dsh-better-sidebar 液态玻璃：一套独立于会话玻璃的细粒度控制（侧栏模糊 /
+  // 侧栏透明度 / 侧栏玻璃颜色 + 总开关）。变量只作用于 [data-dsh-better-sidebar]
+  // 子树（CSS 见下），关闭总开关时侧栏恢复原生外观。
+  s.setProperty("--we-sidebar-blur", selection.sidebarBlur + "px");
+  s.setProperty("--we-sidebar-saturate", String(1.15 + selection.sidebarBlur * 0.028));
+  const sidebarAlpha = Math.max(0.03, 0.25 - (selection.sidebarAlpha / 60) * 0.22);
+  s.setProperty("--we-sidebar-alpha", String(sidebarAlpha));
+  s.setProperty("--we-sidebar-color", selection.sidebarColor);
+  if (selection.sidebarGlass) document.body.setAttribute("data-we-sidebar-glass", "on");
+  else document.body.removeAttribute("data-we-sidebar-glass");
+
   // Scrim immediacy: some composited/kiosk environments do not repaint a
   // z-index:-1 layer promptly when only an inherited CSS variable changes.
   // Write the resolved color DIRECTLY onto the scrim element's inline style and
@@ -1356,6 +1393,11 @@ function clearEffects() {
   s.removeProperty("--we-glass-alpha");
   s.removeProperty("--we-glass-color");
   document.body.removeAttribute("data-we-glass-window");
+  s.removeProperty("--we-sidebar-blur");
+  s.removeProperty("--we-sidebar-saturate");
+  s.removeProperty("--we-sidebar-alpha");
+  s.removeProperty("--we-sidebar-color");
+  document.body.removeAttribute("data-we-sidebar-glass");
   const scrim = document.getElementById(SCRIM_ID);
   if (scrim) scrim.style.background = "";
 }
@@ -1510,6 +1552,21 @@ function WallpaperPicker() {
   };
   const onGlassAlpha = (pct) => {
     selection.glassAlpha = clampNum(pct, 0, 60, DEFAULTS.glassAlpha);
+    persistSelection(); applyEffects(); emit();
+  };
+  // 侧栏玻璃（dsh-better-sidebar）：独立于会话玻璃的一套细粒度控制，各自立即
+  // 生效并持久化（--we-sidebar-blur / --we-sidebar-alpha / --we-sidebar-color）。
+  const onSidebarBlur = (px) => {
+    selection.sidebarBlur = clampNum(px, 0, 60, DEFAULTS.sidebarBlur);
+    persistSelection(); applyEffects(); emit();
+  };
+  const onSidebarAlpha = (pct) => {
+    selection.sidebarAlpha = clampNum(pct, 0, 60, DEFAULTS.sidebarAlpha);
+    persistSelection(); applyEffects(); emit();
+  };
+  const onSidebarColor = (hex) => {
+    if (!/^#[0-9a-f]{6}$/i.test(hex)) return;
+    selection.sidebarColor = hex;
     persistSelection(); applyEffects(); emit();
   };
 
@@ -1683,6 +1740,57 @@ function WallpaperPicker() {
       React.createElement("span", { className: "we-picker__hint" },
         "整个设置窗口（含 General / 模型 / 插件等全部原生分区）跟随配色与透明度；关闭则恢复原生样式",
       ),
+      // 侧栏玻璃（dsh-better-sidebar 适配）：与设置窗口玻璃同级的一套独立细粒度
+      // 控制 —— 总开关 + 专用模糊 + 专用透明度 + 玻璃基底色调，全部只作用于
+      // dsh-better-sidebar 子树，不动会话玻璃（玻璃 / 玻璃透明度）的设置。
+      // 仅在 host 检测到 dsh-better-sidebar 已安装且启用时显示（sidebarPresent）。
+      // 开关本体 + 说明始终显示；三个细节滑块（侧栏模糊 / 侧栏透明度 / 侧栏玻璃
+      // 颜色）以「侧栏液态玻璃」开关为前提 —— 关闭时隐藏，开启后随 emit 重渲染
+      // 实时出现（滑块只在毛玻璃生效时有意义）。
+      sel.sidebarPresent && [
+      React.createElement("label", { className: "we-picker__rotation-toggle we-picker__window-toggle" },
+        React.createElement("input", {
+          type: "checkbox",
+          checked: sel.sidebarGlass,
+          onChange: (e) => {
+            selection.sidebarGlass = e.target.checked;
+            persistSelection();
+            applyEffects();
+            emit();
+          },
+        }),
+        "侧栏液态玻璃",
+      ),
+      React.createElement("span", { className: "we-picker__hint" },
+        "dsh-better-sidebar 侧栏（文件 / 终端 / Git 等面板）的毛玻璃适配；关闭则恢复其原生外观",
+      ),
+      ],
+      sel.sidebarPresent && sel.sidebarGlass && [
+      SliderRow("侧栏模糊", 0, 60, 1, sel.sidebarBlur, onSidebarBlur, sel.sidebarBlur + "px"),
+      SliderRow("侧栏透明度", 0, 60, 5, sel.sidebarAlpha, onSidebarAlpha, sel.sidebarAlpha + "%"),
+      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "侧栏玻璃颜色"),
+        GLASS_COLOR_PRESETS.map((hex) => React.createElement("button", {
+          key: hex,
+          className: "we-picker__swatch" + (sel.sidebarColor === hex ? " we-picker__swatch--active" : ""),
+          type: "button",
+          style: { background: hex },
+          title: hex,
+          onClick: () => onSidebarColor(hex),
+          "aria-label": "侧栏玻璃颜色 " + hex,
+        })),
+        React.createElement("label", { className: "we-picker__swatch-custom" },
+          React.createElement("input", {
+            type: "color",
+            value: sel.sidebarColor,
+            onInput: (e) => onSidebarColor(e.target.value),
+            onChange: (e) => onSidebarColor(e.target.value),
+            title: "自定义侧栏玻璃颜色",
+          }),
+          React.createElement("span", { className: "we-picker__hint" }, "自定义"),
+        ),
+      ),
+      ],
     ),
     // ── Card-style switch: classic (WE's original aspect-ratio 16/9 cards —
     //    the CD-like look the author liked) vs the rewritten fixed-height
@@ -2483,44 +2591,69 @@ const CSS = `
      target the whole tree without depending on its CSS-module hashes. Its root
      panels read the opaque --dsw-alias-bg-layer-1 token (hence the "black
      frame") — give them the SAME clear liquid-glass recipe as the
-     composer/bubbles (faint specular sheen + gentle frosted melt), with blur
-     radius + saturation driven by the 玻璃 slider (--we-blur / --we-saturate).
+     composer/bubbles (faint specular sheen + gentle frosted melt).
+     Unlike the conversation surfaces, the sidebar glass is FULLY independent:
+     the master switch body[data-we-sidebar-glass] (侧栏液态玻璃) gates the whole
+     adaptation, and blur / saturation / transparency / base tint each have
+     their own knob (--we-sidebar-blur / --we-sidebar-saturate /
+     --we-sidebar-alpha / --we-sidebar-color, from 侧栏模糊 / 侧栏透明度 /
+     侧栏玻璃颜色), so the sidebar can be blurrier, clearer, more transparent
+     or tinted however you like without touching the 玻璃 / 玻璃透明度 sliders.
      Inner chrome surfaces that paint the same opaque tokens get a translucent
      base too; the blur lives on the root panels (one blur per shell). */
-  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
-  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
-    background-color: rgba(255, 255, 255, calc(var(--we-glass-alpha, 0.15) * 0.66)) !important;
+  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
+  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
+    background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.66 * 100%), transparent) !important;
     background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.04) 38%, rgba(255, 255, 255, 0.01)) !important;
-    -webkit-backdrop-filter: blur(var(--we-blur, 16px)) saturate(var(--we-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
-    backdrop-filter: blur(var(--we-blur, 16px)) saturate(var(--we-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
+    -webkit-backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
+    backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, var(--we-glass-highlight, 0.32)),
       inset 0 -1px 0 rgba(255, 255, 255, 0.08),
       inset 0 0 0 0.5px rgba(255, 255, 255, 0.06);
   }
-  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
-  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],
-  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_paneCard"],
-  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_editorHeader"],
-  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_explorerHeader"],
-  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_gitHeader"],
-  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_browserBar"],
-  body[data-we-wallpaper] [data-dsh-better-sidebar] [class*="_terminalWrap"] {
-    background-color: rgba(255, 255, 255, calc(var(--we-glass-alpha, 0.15) * 0.53)) !important;
+  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
+  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],
+  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_paneCard"],
+  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_editorHeader"],
+  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_explorerHeader"],
+  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_gitHeader"],
+  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_browserBar"],
+  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_terminalWrap"] {
+    background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.53 * 100%), transparent) !important;
   }
-  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
-  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
-    background-color: rgba(255, 255, 255, calc(var(--we-glass-alpha, 0.15) * 0.33)) !important;
+  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
+  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
+    background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.33 * 100%), transparent) !important;
   }
-  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
-  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],
-  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_paneCard"],
-  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_editorHeader"],
-  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_explorerHeader"],
-  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_gitHeader"],
-  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_browserBar"],
-  body[data-ds-dark-theme][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_terminalWrap"] {
-    background-color: rgba(255, 255, 255, calc(var(--we-glass-alpha, 0.15) * 0.26)) !important;
+  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
+  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],
+  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_paneCard"],
+  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_editorHeader"],
+  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_explorerHeader"],
+  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_gitHeader"],
+  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_browserBar"],
+  body[data-ds-dark-theme][data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_terminalWrap"] {
+    background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.26 * 100%), transparent) !important;
+  }
+  /* No backdrop-filter support: fall back to near-opaque tinted surfaces so
+     sidebar text never sits directly on a busy wallpaper (same policy as the
+     settings-window glass). The tint still applies. */
+  @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
+    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"],
+    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
+    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],
+    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_paneCard"],
+    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_editorHeader"],
+    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_explorerHeader"],
+    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_gitHeader"],
+    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_browserBar"],
+    body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_terminalWrap"] {
+      background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) 92%, transparent) !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+    }
   }
 
   /* Picker chrome. */


### PR DESCRIPTION
## 动机
dsh-better-sidebar 适配原本只有毛玻璃质感，但自由度不够：模糊/透明度与会话玻璃
共用滑块、固定白色、无总开关、无安装检测（未装侧栏时也显示控制项）。

## 改动
- 侧栏液态玻璃（sidebarGlass）总开关，关闭恢复侧栏原生外观；
- 侧栏模糊 / 侧栏透明度 / 侧栏玻璃颜色 三组独立控制，不再与「玻璃 / 玻璃透明度」
  互相牵制；三个细节项以总开关为前提，关闭时隐藏、开启后实时出现；
- 安装检测：宿主遍历 cordis loader 条目树（ctx.loader.entries()，匹配
  entry.options.name === 'dsh-better-sidebar'，兼容 dsh-remote 聚合挂载），
  通过 settings GET 返回 betterSidebar，设置页仅在已安装且启用时显示控制组；
- CSS：侧栏玻璃规则改用 --we-sidebar-* 变量 + color-mix 色调，无
  backdrop-filter 时回退近不透明（与设置窗口玻璃同策略）；
- 宿主 sanitize 镜像同步新字段。

## 测试
verify-client 新增断言：betterSidebar=true 时控制组渲染（开关/两滑块/6 色板/
自定义色），开关关闭隐藏三滑块、重开恢复。npm run verify 通过。