### PR TITLE
feat: sidebar content surfaces get tunable near-opaque glass

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1415,9 +1415,17 @@ window.__ModuleLoader__.load({
 		  s.setProperty("--we-sidebar-blur", selection.sidebarBlur + "px");
 		  // 饱和度随模糊增长但封顶（blur 最大 100px 时 1.15+2.8=3.95 过于夸张）。
 		  s.setProperty("--we-sidebar-saturate", String(Math.min(3.2, 1.15 + selection.sidebarBlur * 0.028)));
-		  // 透明度 0–100 全范围映射：0 → 0.25（近实色），100 → 0.03（接近全透）。
-		  const sidebarAlpha = Math.max(0.03, 0.25 - (selection.sidebarAlpha / 100) * 0.22);
+		  // 透明度 0–100 全范围映射：0 → 0.9（近实色），12%（默认）→ 0.2236（保持
+		  // 既有观感不变），100 → 0.03（近全透）。分段线性以默认值为拐点——旧的
+		  // 0.25 上限在 0% 时只有 16.5% 白（壁纸几乎全透出，实测"0% 也极其透明"）。
+		  // sheen 因子 = min(1, alpha/0.2236)：比默认更实时维持原设计高光强度，
+		  // 只有往透明方向衰减（100% 时白色釉面随之消失）。
+		  const sidebarAlphaPct = selection.sidebarAlpha;
+		  const sidebarAlpha = sidebarAlphaPct <= 12
+		    ? 0.9 - (sidebarAlphaPct / 12) * (0.9 - 0.2236)
+		    : 0.2236 - ((sidebarAlphaPct - 12) / 88) * (0.2236 - 0.03);
 		  s.setProperty("--we-sidebar-alpha", String(sidebarAlpha));
+		  s.setProperty("--we-sidebar-sheen", String(Math.min(1, sidebarAlpha / 0.2236)));
 		  s.setProperty("--we-sidebar-color", selection.sidebarColor);
 		  if (selection.sidebarGlass) document.body.setAttribute("data-we-sidebar-glass", "on");
 		  else document.body.removeAttribute("data-we-sidebar-glass");
@@ -1463,6 +1471,7 @@ window.__ModuleLoader__.load({
 		  s.removeProperty("--we-sidebar-blur");
 		  s.removeProperty("--we-sidebar-saturate");
 		  s.removeProperty("--we-sidebar-alpha");
+		  s.removeProperty("--we-sidebar-sheen");
 		  s.removeProperty("--we-sidebar-color");
 		  document.body.removeAttribute("data-we-sidebar-glass");
 		  s.removeProperty("--we-content-surface-alpha");
@@ -2721,20 +2730,21 @@ window.__ModuleLoader__.load({
 		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
 		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
 		    background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.66 * 100%), transparent) !important;
-		    /* Specular sheen + refraction highlights SCALE with --we-sidebar-alpha
-		       (coefficients keep the 12% default look identical: 0.626*0.2236≈0.14,
-		       1.43*0.2236≈0.32 …). At 100% transparency the white glaze fades out too,
-		       so the sidebar is truly near-transparent instead of pale white. */
+		    /* Specular sheen + refraction highlights follow --we-sidebar-sheen
+		       (= min(1, alpha/0.2236)): at default (12%) and any MORE solid setting
+		       the sheen keeps the ORIGINAL design strength (0.14/0.04/0.01,
+		       0.32/0.08/0.06); only toward transparency does the white glaze fade,
+		       so 100% is truly near-transparent instead of pale white. */
 		    background-image: linear-gradient(180deg,
-		      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.626)),
-		      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.179)) 38%,
-		      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.045))) !important;
+		      rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.14)),
+		      rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.04)) 38%,
+		      rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.01))) !important;
 		    -webkit-backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
 		    backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
 		    box-shadow:
-		      inset 0 1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 1.43)),
-		      inset 0 -1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.358)),
-		      inset 0 0 0 0.5px rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.268));
+		      inset 0 1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.32)),
+		      inset 0 -1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.08)),
+		      inset 0 0 0 0.5px rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.06));
 		  }
 		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
 		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],

--- a/lib/client.js
+++ b/lib/client.js
@@ -114,6 +114,15 @@ window.__ModuleLoader__.load({
 		  sidebarBlur: 16,
 		  sidebarAlpha: 12,
 		  sidebarColor: "#ffffff",
+		  // 内容面（编辑器/终端）近不透明玻璃底的细调——既有固定调色板（语法高亮/
+		  // ANSI）为不透明底设计，全透明毛玻璃下注释灰不可读，全不透明又失去玻璃感：
+		  // - sidebarContentAlpha：内容面透明度（%），越大越透（映射到底色不透明度
+		  //   100%→50%；默认 30 → 70% 不透明，亮/暗主题实测显示均合理，玻璃感与
+		  //   注释可读性平衡）；
+		  // - sidebarContentColor：内容面底色（#rrggbb），空 = 跟随主题面板色
+		  //   (--dsw-alias-bg-layer-1)，选定后双主题统一使用该色。
+		  sidebarContentAlpha: 30,
+		  sidebarContentColor: "",
 		};
 
 		// Selectable values for the two filters. Declared up top because
@@ -219,6 +228,9 @@ window.__ModuleLoader__.load({
 		    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, DEFAULTS.sidebarAlpha),
 		    sidebarColor: typeof o.sidebarColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
 		      ? o.sidebarColor : DEFAULTS.sidebarColor,
+		    sidebarContentAlpha: clampNum(o.sidebarContentAlpha, 0, 50, DEFAULTS.sidebarContentAlpha),
+		    sidebarContentColor: typeof o.sidebarContentColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarContentColor)
+		      ? o.sidebarContentColor : DEFAULTS.sidebarContentColor,
 		  };
 		}
 
@@ -325,6 +337,8 @@ window.__ModuleLoader__.load({
 		    sidebarBlur: selection.sidebarBlur,
 		    sidebarAlpha: selection.sidebarAlpha,
 		    sidebarColor: selection.sidebarColor,
+		    sidebarContentAlpha: selection.sidebarContentAlpha,
+		    sidebarContentColor: selection.sidebarContentColor,
 		  };
 		}
 
@@ -1405,6 +1419,13 @@ window.__ModuleLoader__.load({
 		  s.setProperty("--we-sidebar-color", selection.sidebarColor);
 		  if (selection.sidebarGlass) document.body.setAttribute("data-we-sidebar-glass", "on");
 		  else document.body.removeAttribute("data-we-sidebar-glass");
+		  // 内容面（编辑器/终端）近不透明玻璃底：透明度滑块 0–50 → 不透明度 100%–50%
+		  // （越大越透，与玻璃透明度同语义）；底色空 = 跟随主题面板色，选定后自定义。
+		  // 注意 color-mix 的百分比槽位要求带单位的 token —— 变量值必须含 "%"，
+		  // 否则整个 color-mix 失效、底色规则被丢弃（编辑器回退到纯透明毛玻璃）。
+		  s.setProperty("--we-content-surface-alpha", Math.max(50, 100 - selection.sidebarContentAlpha) + "%");
+		  if (selection.sidebarContentColor) s.setProperty("--we-content-surface-color", selection.sidebarContentColor);
+		  else s.removeProperty("--we-content-surface-color");
 
 		  // Scrim immediacy: some composited/kiosk environments do not repaint a
 		  // z-index:-1 layer promptly when only an inherited CSS variable changes.
@@ -1441,6 +1462,8 @@ window.__ModuleLoader__.load({
 		  s.removeProperty("--we-sidebar-alpha");
 		  s.removeProperty("--we-sidebar-color");
 		  document.body.removeAttribute("data-we-sidebar-glass");
+		  s.removeProperty("--we-content-surface-alpha");
+		  s.removeProperty("--we-content-surface-color");
 		  const scrim = document.getElementById(SCRIM_ID);
 		  if (scrim) scrim.style.background = "";
 		}
@@ -1610,6 +1633,21 @@ window.__ModuleLoader__.load({
 		  const onSidebarColor = (hex) => {
 		    if (!/^#[0-9a-f]{6}$/i.test(hex)) return;
 		    selection.sidebarColor = hex;
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  // 内容面（编辑器/终端）近不透明玻璃底：透明度滑块 + 底色（空 = 跟随主题）。
+		  const onSidebarContentAlpha = (pct) => {
+		    selection.sidebarContentAlpha = clampNum(pct, 0, 50, DEFAULTS.sidebarContentAlpha);
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  const onSidebarContentColor = (hex) => {
+		    if (hex === "") {
+		      selection.sidebarContentColor = ""; // 跟随主题面板色
+		      persistSelection(); applyEffects(); emit();
+		      return;
+		    }
+		    if (!/^#[0-9a-f]{6}$/i.test(hex)) return;
+		    selection.sidebarContentColor = hex;
 		    persistSelection(); applyEffects(); emit();
 		  };
 
@@ -1829,6 +1867,39 @@ window.__ModuleLoader__.load({
 		            onInput: (e) => onSidebarColor(e.target.value),
 		            onChange: (e) => onSidebarColor(e.target.value),
 		            title: "自定义侧栏玻璃颜色",
+		          }),
+		          React.createElement("span", { className: "we-picker__hint" }, "自定义"),
+		        ),
+		      ),
+		      // 内容面（编辑器 / 终端）近不透明玻璃底：透明度 + 底色。固定调色板
+		      // （语法高亮 / ANSI）为不透明底设计，全透毛玻璃下注释灰不可读；这里
+		      // 在"玻璃感"与"可读性"之间取平衡——透明度越大越透，底色空 = 跟随主题。
+		      SliderRow("内容面透明度", 0, 50, 5, sel.sidebarContentAlpha, onSidebarContentAlpha, sel.sidebarContentAlpha + "%"),
+		      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+		        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "内容面底色"),
+		        React.createElement("button", {
+		          className: "we-picker__swatch we-picker__swatch--auto" + (sel.sidebarContentColor === "" ? " we-picker__swatch--active" : ""),
+		          type: "button",
+		          title: "跟随主题面板色",
+		          onClick: () => onSidebarContentColor(""),
+		          "aria-label": "内容面底色 跟随主题",
+		        }, "主题"),
+		        GLASS_COLOR_PRESETS.map((hex) => React.createElement("button", {
+		          key: hex,
+		          className: "we-picker__swatch" + (sel.sidebarContentColor === hex ? " we-picker__swatch--active" : ""),
+		          type: "button",
+		          style: { background: hex },
+		          title: hex,
+		          onClick: () => onSidebarContentColor(hex),
+		          "aria-label": "内容面底色 " + hex,
+		        })),
+		        React.createElement("label", { className: "we-picker__swatch-custom" },
+		          React.createElement("input", {
+		            type: "color",
+		            value: sel.sidebarContentColor || "#1e1f26",
+		            onInput: (e) => onSidebarContentColor(e.target.value),
+		            onChange: (e) => onSidebarContentColor(e.target.value),
+		            title: "自定义内容面底色",
 		          }),
 		          React.createElement("span", { className: "we-picker__hint" }, "自定义"),
 		        ),
@@ -2699,6 +2770,28 @@ window.__ModuleLoader__.load({
 		    }
 		  }
 
+		  /* ── dsh-better-sidebar CONTENT surfaces: near-opaque tinted glass ─────────
+		     The editor (CodeMirror) surface is transparent by design, and the terminal
+		     background reads --dsw-alias-bg-base — which we must keep transparent so
+		     the wallpaper shows through. Their fixed content palettes (syntax
+		     highlighting / ANSI colors) are designed for an OPAQUE backdrop (One
+		     Dark/Light, xterm themes): on the fully frosted composite the mid-gray
+		     comments etc. lose all contrast (实测注释灰 1.7–2.3:1，看不清).
+		     Fully opaque surfaces fix readability but kill the glass look. Balance:
+		     a NEAR-OPAQUE TINTED glass plate — the theme's opaque panel color
+		     (--dsw-alias-bg-layer-1) at 88% keeps the wallpaper glow bleeding through
+		     (still reads as glass) while the composite stays dark/light enough for the
+		     the designed content palettes. Tune via the 内容面透明度 / 内容面底色 controls
+		     (--we-content-surface-alpha / --we-content-surface-color; color empty =
+		     follow the theme panel color). Gated on data-we-wallpaper, NOT the
+		     sidebar-glass switch — the terminal turns transparent even with the switch
+		     off. .cm-editor / .xterm are library-global class names (stable across the
+		     sidebar's builds). */
+		  body[data-we-wallpaper] [data-dsh-better-sidebar] .cm-editor,
+		  body[data-we-wallpaper] [data-dsh-better-sidebar] .xterm {
+		    background-color: color-mix(in srgb, var(--we-content-surface-color, var(--dsw-alias-bg-layer-1, #1e1f26)) var(--we-content-surface-alpha, 88%), transparent) !important;
+		  }
+
 		  /* Picker chrome. */
 		  .we-picker { display: flex; flex-direction: column; gap: 10px; }
 		  .we-picker__select { max-width: 100%; }
@@ -2846,6 +2939,14 @@ window.__ModuleLoader__.load({
 		  .we-picker__swatch:hover { transform: scale(1.12); }
 		  .we-picker__swatch--active {
 		    box-shadow: 0 0 0 2px var(--we-accent, #4f8cff), 0 0 0 4px rgba(255, 255, 255, 0.5);
+		  }
+		  /* "跟随主题" auto swatch (内容面底色): no fill, split ring showing both
+		     themes so it reads as "use the theme panel color". */
+		  .we-picker__swatch--auto {
+		    font-size: 10px; line-height: 1; font-weight: 600;
+		    color: var(--dsw-alias-label-secondary, #666);
+		    background: linear-gradient(135deg, #2a2d35 0 50%, #f2f3f5 50% 100%);
+		    display: inline-flex; align-items: center; justify-content: center;
 		  }
 		  .we-picker__swatch-custom {
 		    display: inline-flex; align-items: center; gap: 4px; cursor: pointer;

--- a/lib/client.js
+++ b/lib/client.js
@@ -117,7 +117,7 @@ window.__ModuleLoader__.load({
 		  // 内容面（编辑器/终端）近不透明玻璃底的细调——既有固定调色板（语法高亮/
 		  // ANSI）为不透明底设计，全透明毛玻璃下注释灰不可读，全不透明又失去玻璃感：
 		  // - sidebarContentAlpha：内容面透明度（%），越大越透（映射到底色不透明度
-		  //   100%→50%；默认 30 → 70% 不透明，亮/暗主题实测显示均合理，玻璃感与
+		  //   100%→20%；默认 30 → 70% 不透明，亮/暗主题实测显示均合理，玻璃感与
 		  //   注释可读性平衡）；
 		  // - sidebarContentColor：内容面底色（#rrggbb），空 = 跟随主题面板色
 		  //   (--dsw-alias-bg-layer-1)，选定后双主题统一使用该色。
@@ -224,11 +224,11 @@ window.__ModuleLoader__.load({
 		      ? o.glassColor : DEFAULTS.glassColor,
 		    glassWindow: o.glassWindow !== false,
 		    sidebarGlass: o.sidebarGlass !== false,
-		    sidebarBlur: clampNum(o.sidebarBlur, 0, 60, DEFAULTS.sidebarBlur),
-		    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, DEFAULTS.sidebarAlpha),
+		    sidebarBlur: clampNum(o.sidebarBlur, 0, 100, DEFAULTS.sidebarBlur),
+		    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 100, DEFAULTS.sidebarAlpha),
 		    sidebarColor: typeof o.sidebarColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
 		      ? o.sidebarColor : DEFAULTS.sidebarColor,
-		    sidebarContentAlpha: clampNum(o.sidebarContentAlpha, 0, 50, DEFAULTS.sidebarContentAlpha),
+		    sidebarContentAlpha: clampNum(o.sidebarContentAlpha, 0, 80, DEFAULTS.sidebarContentAlpha),
 		    sidebarContentColor: typeof o.sidebarContentColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarContentColor)
 		      ? o.sidebarContentColor : DEFAULTS.sidebarContentColor,
 		  };
@@ -1413,17 +1413,20 @@ window.__ModuleLoader__.load({
 		  // 侧栏透明度 / 侧栏玻璃颜色 + 总开关）。变量只作用于 [data-dsh-better-sidebar]
 		  // 子树（CSS 见下），关闭总开关时侧栏恢复原生外观。
 		  s.setProperty("--we-sidebar-blur", selection.sidebarBlur + "px");
-		  s.setProperty("--we-sidebar-saturate", String(1.15 + selection.sidebarBlur * 0.028));
-		  const sidebarAlpha = Math.max(0.03, 0.25 - (selection.sidebarAlpha / 60) * 0.22);
+		  // 饱和度随模糊增长但封顶（blur 最大 100px 时 1.15+2.8=3.95 过于夸张）。
+		  s.setProperty("--we-sidebar-saturate", String(Math.min(3.2, 1.15 + selection.sidebarBlur * 0.028)));
+		  // 透明度 0–100 全范围映射：0 → 0.25（近实色），100 → 0.03（接近全透）。
+		  const sidebarAlpha = Math.max(0.03, 0.25 - (selection.sidebarAlpha / 100) * 0.22);
 		  s.setProperty("--we-sidebar-alpha", String(sidebarAlpha));
 		  s.setProperty("--we-sidebar-color", selection.sidebarColor);
 		  if (selection.sidebarGlass) document.body.setAttribute("data-we-sidebar-glass", "on");
 		  else document.body.removeAttribute("data-we-sidebar-glass");
-		  // 内容面（编辑器/终端）近不透明玻璃底：透明度滑块 0–50 → 不透明度 100%–50%
-		  // （越大越透，与玻璃透明度同语义）；底色空 = 跟随主题面板色，选定后自定义。
+		  // 内容面（编辑器/终端）近不透明玻璃底：透明度滑块 0–80 → 不透明度 100%–20%
+		  // （越大越透，与玻璃透明度同语义；低于 ~40% 不透明度注释可读性会再次变差，
+		  // 留给用户自行权衡）；底色空 = 跟随主题面板色，选定后自定义。
 		  // 注意 color-mix 的百分比槽位要求带单位的 token —— 变量值必须含 "%"，
 		  // 否则整个 color-mix 失效、底色规则被丢弃（编辑器回退到纯透明毛玻璃）。
-		  s.setProperty("--we-content-surface-alpha", Math.max(50, 100 - selection.sidebarContentAlpha) + "%");
+		  s.setProperty("--we-content-surface-alpha", Math.max(20, 100 - selection.sidebarContentAlpha) + "%");
 		  if (selection.sidebarContentColor) s.setProperty("--we-content-surface-color", selection.sidebarContentColor);
 		  else s.removeProperty("--we-content-surface-color");
 
@@ -1623,11 +1626,11 @@ window.__ModuleLoader__.load({
 		  // 侧栏玻璃（dsh-better-sidebar）：独立于会话玻璃的一套细粒度控制，各自立即
 		  // 生效并持久化（--we-sidebar-blur / --we-sidebar-alpha / --we-sidebar-color）。
 		  const onSidebarBlur = (px) => {
-		    selection.sidebarBlur = clampNum(px, 0, 60, DEFAULTS.sidebarBlur);
+		    selection.sidebarBlur = clampNum(px, 0, 100, DEFAULTS.sidebarBlur);
 		    persistSelection(); applyEffects(); emit();
 		  };
 		  const onSidebarAlpha = (pct) => {
-		    selection.sidebarAlpha = clampNum(pct, 0, 60, DEFAULTS.sidebarAlpha);
+		    selection.sidebarAlpha = clampNum(pct, 0, 100, DEFAULTS.sidebarAlpha);
 		    persistSelection(); applyEffects(); emit();
 		  };
 		  const onSidebarColor = (hex) => {
@@ -1637,7 +1640,7 @@ window.__ModuleLoader__.load({
 		  };
 		  // 内容面（编辑器/终端）近不透明玻璃底：透明度滑块 + 底色（空 = 跟随主题）。
 		  const onSidebarContentAlpha = (pct) => {
-		    selection.sidebarContentAlpha = clampNum(pct, 0, 50, DEFAULTS.sidebarContentAlpha);
+		    selection.sidebarContentAlpha = clampNum(pct, 0, 80, DEFAULTS.sidebarContentAlpha);
 		    persistSelection(); applyEffects(); emit();
 		  };
 		  const onSidebarContentColor = (hex) => {
@@ -1847,8 +1850,8 @@ window.__ModuleLoader__.load({
 		      ),
 		      ],
 		      sel.sidebarPresent && sel.sidebarGlass && [
-		      SliderRow("侧栏模糊", 0, 60, 1, sel.sidebarBlur, onSidebarBlur, sel.sidebarBlur + "px"),
-		      SliderRow("侧栏透明度", 0, 60, 5, sel.sidebarAlpha, onSidebarAlpha, sel.sidebarAlpha + "%"),
+		      SliderRow("侧栏模糊", 0, 100, 1, sel.sidebarBlur, onSidebarBlur, sel.sidebarBlur + "px"),
+		      SliderRow("侧栏透明度", 0, 100, 5, sel.sidebarAlpha, onSidebarAlpha, sel.sidebarAlpha + "%"),
 		      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
 		        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "侧栏玻璃颜色"),
 		        GLASS_COLOR_PRESETS.map((hex) => React.createElement("button", {
@@ -1874,7 +1877,7 @@ window.__ModuleLoader__.load({
 		      // 内容面（编辑器 / 终端）近不透明玻璃底：透明度 + 底色。固定调色板
 		      // （语法高亮 / ANSI）为不透明底设计，全透毛玻璃下注释灰不可读；这里
 		      // 在"玻璃感"与"可读性"之间取平衡——透明度越大越透，底色空 = 跟随主题。
-		      SliderRow("内容面透明度", 0, 50, 5, sel.sidebarContentAlpha, onSidebarContentAlpha, sel.sidebarContentAlpha + "%"),
+		      SliderRow("内容面透明度", 0, 80, 5, sel.sidebarContentAlpha, onSidebarContentAlpha, sel.sidebarContentAlpha + "%"),
 		      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
 		        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "内容面底色"),
 		        React.createElement("button", {

--- a/lib/client.js
+++ b/lib/client.js
@@ -2721,13 +2721,20 @@ window.__ModuleLoader__.load({
 		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
 		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
 		    background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.66 * 100%), transparent) !important;
-		    background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.04) 38%, rgba(255, 255, 255, 0.01)) !important;
+		    /* Specular sheen + refraction highlights SCALE with --we-sidebar-alpha
+		       (coefficients keep the 12% default look identical: 0.626*0.2236≈0.14,
+		       1.43*0.2236≈0.32 …). At 100% transparency the white glaze fades out too,
+		       so the sidebar is truly near-transparent instead of pale white. */
+		    background-image: linear-gradient(180deg,
+		      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.626)),
+		      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.179)) 38%,
+		      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.045))) !important;
 		    -webkit-backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
 		    backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
 		    box-shadow:
-		      inset 0 1px 0 rgba(255, 255, 255, var(--we-glass-highlight, 0.32)),
-		      inset 0 -1px 0 rgba(255, 255, 255, 0.08),
-		      inset 0 0 0 0.5px rgba(255, 255, 255, 0.06);
+		      inset 0 1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 1.43)),
+		      inset 0 -1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.358)),
+		      inset 0 0 0 0.5px rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.268));
 		  }
 		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
 		  body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -532,6 +532,9 @@ function sanitizeSettings(raw) {
     sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, 12),
     sidebarColor: typeof o.sidebarColor === 'string' && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
       ? o.sidebarColor : '#ffffff',
+    sidebarContentAlpha: clampNum(o.sidebarContentAlpha, 0, 50, 30),
+    sidebarContentColor: typeof o.sidebarContentColor === 'string' && /^#[0-9a-f]{6}$/i.test(o.sidebarContentColor)
+      ? o.sidebarContentColor : '',
   };
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -528,11 +528,11 @@ function sanitizeSettings(raw) {
     glassWindow: o.glassWindow !== false,
     // dsh-better-sidebar glass knobs (mirror of src/client.js).
     sidebarGlass: o.sidebarGlass !== false,
-    sidebarBlur: clampNum(o.sidebarBlur, 0, 60, 16),
-    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, 12),
+    sidebarBlur: clampNum(o.sidebarBlur, 0, 100, 16),
+    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 100, 12),
     sidebarColor: typeof o.sidebarColor === 'string' && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
       ? o.sidebarColor : '#ffffff',
-    sidebarContentAlpha: clampNum(o.sidebarContentAlpha, 0, 50, 30),
+    sidebarContentAlpha: clampNum(o.sidebarContentAlpha, 0, 80, 30),
     sidebarContentColor: typeof o.sidebarContentColor === 'string' && /^#[0-9a-f]{6}$/i.test(o.sidebarContentColor)
       ? o.sidebarContentColor : '',
   };

--- a/scripts/verify-client.mjs
+++ b/scripts/verify-client.mjs
@@ -152,6 +152,9 @@ setTimeout(() => {
   console.log('--we-scrim-color:', JSON.stringify(p['--we-scrim-color']));
   console.log('--we-border-alpha:', JSON.stringify(p['--we-border-alpha']));
   console.log('--we-blur:', JSON.stringify(p['--we-blur']));
+  // color-mix 的百分比槽位要求带单位的 token：内容面不透明度变量必须以 "%"
+  // 结尾，否则整条 background-color 规则失效（回归防护，见 applyEffects）。
+  console.log('--we-content-surface-alpha ends with %:', String(p['--we-content-surface-alpha'] || '').endsWith('%'));
   console.log('--we-wallpaper-blur:', JSON.stringify(p['--we-wallpaper-blur']));
   console.log('--we-wallpaper-scale:', JSON.stringify(p['--we-wallpaper-scale']));
   console.log('--we-accent:', JSON.stringify(p['--we-accent']));
@@ -196,9 +199,13 @@ setTimeout(() => {
       console.log('sidebar alpha slider present:', treeText.includes('侧栏透明度'));
       console.log('sidebar glass-color swatches (expect 6):', (treeText.match(/"aria-label":"侧栏玻璃颜色 /g) || []).length);
       console.log('sidebar glass color custom input present:', treeText.includes('自定义侧栏玻璃颜色'));
-      // The three detail knobs (侧栏模糊 / 侧栏透明度 / 侧栏玻璃颜色) are
-      // conditional on the 侧栏液态玻璃 master switch: off → hidden, on →
-      // restored, in the SAME render pass (the toggle re-emits synchronously).
+      console.log('sidebar content-alpha slider present:', treeText.includes('内容面透明度'));
+      console.log('sidebar content auto swatch present:', treeText.includes('内容面底色 跟随主题'));
+      console.log('sidebar content color swatches (expect 7 = 6 presets + auto):', (treeText.match(/"aria-label":"内容面底色 /g) || []).length);
+      console.log('sidebar content color custom input present:', treeText.includes('自定义内容面底色'));
+      // The detail knobs (侧栏模糊 / 侧栏透明度 / 侧栏玻璃颜色 / 内容面透明度 /
+      // 内容面底色) are conditional on the 侧栏液态玻璃 master switch: off →
+      // hidden, on → restored, in the SAME render pass (toggle re-emits sync).
       const sidebarSwitch = (() => {
         let hit = null;
         (function walk(node) {
@@ -217,15 +224,18 @@ setTimeout(() => {
         sidebarSwitch.props.onChange({ target: { checked: false } });
         tree = pickerRenders[0]();
         const offText = JSON.stringify(tree);
-        console.log('switch off hides the three detail knobs:',
-          !offText.includes('侧栏模糊') && !offText.includes('侧栏透明度') && !offText.includes('侧栏玻璃颜色'));
+        console.log('switch off hides the detail knobs:',
+          !offText.includes('侧栏模糊') && !offText.includes('侧栏透明度') && !offText.includes('侧栏玻璃颜色')
+          && !offText.includes('内容面透明度') && !offText.includes('内容面底色'));
         console.log('switch itself stays visible when off:', offText.includes('侧栏液态玻璃'));
         sidebarSwitch.props.onChange({ target: { checked: true } });
         tree = pickerRenders[0]();
         console.log('switch back on restores the detail knobs:',
-          JSON.stringify(tree).includes('侧栏模糊') && JSON.stringify(tree).includes('侧栏透明度') && JSON.stringify(tree).includes('侧栏玻璃颜色'));
+          JSON.stringify(tree).includes('侧栏模糊') && JSON.stringify(tree).includes('侧栏透明度')
+          && JSON.stringify(tree).includes('侧栏玻璃颜色') && JSON.stringify(tree).includes('内容面透明度')
+          && JSON.stringify(tree).includes('内容面底色'));
       } else {
-        console.log('switch off hides the three detail knobs: false (switch not found)');
+        console.log('switch off hides the detail knobs: false (switch not found)');
       }
       // 玻璃 slider now spans 0–60 px (was 0–40): assert the raised max on the
       // 玻璃 range input (label "玻璃", max 60) so the range stays in sync.

--- a/scripts/verify-client.mjs
+++ b/scripts/verify-client.mjs
@@ -254,6 +254,59 @@ setTimeout(() => {
       })();
       const sliderMax = glassSlider ? JSON.stringify(glassSlider).match(/"max":"(\d+)"/)?.[1] : null;
       console.log('玻璃 slider max (expect 60):', sliderMax);
+      // Sidebar glass sliders: expanded ranges (侧栏模糊/侧栏透明度 0–100,
+      // 内容面透明度 0–80) — find each by label and assert its max.
+      const sidebarSliderMax = (label) => {
+        let hit = null;
+        (function walk(node) {
+          if (Array.isArray(node)) { node.forEach(walk); return; }
+          if (!node || typeof node !== 'object') return;
+          const cls = typeof node.props?.className === 'string' ? node.props.className : '';
+          const children = Array.isArray(node.children) ? node.children : [];
+          const labelChild = children.find((c) => c && typeof c === 'object' && Array.isArray(c.children) && c.children.includes(label));
+          if (cls.includes('we-picker__slider-row') && labelChild) hit = node;
+          if (Array.isArray(node.children)) node.children.forEach(walk);
+        })(tree);
+        return hit ? JSON.stringify(hit).match(/"max":"(\d+)"/)?.[1] : null;
+      };
+      console.log('侧栏模糊 slider max (expect 100):', sidebarSliderMax('侧栏模糊'));
+      console.log('侧栏透明度 slider max (expect 100):', sidebarSliderMax('侧栏透明度'));
+      console.log('内容面透明度 slider max (expect 80):', sidebarSliderMax('内容面透明度'));
+      // Regression: handler clamps must match the slider maxes — dragging
+      // 侧栏模糊 to 80 (beyond the OLD 60 bound) must PERSIST, not snap back to
+      // the default (a stale clampNum(px, 0, 60, 16) returns the fallback 16).
+      const dragSidebarSlider = (label, value) => {
+        let input = null;
+        (function walk(node) {
+          if (Array.isArray(node)) { node.forEach(walk); return; }
+          if (!node || typeof node !== 'object') return;
+          const children = Array.isArray(node.children) ? node.children : [];
+          const labelChild = children.find((c) => c && typeof c === 'object' && Array.isArray(c.children) && c.children.includes(label));
+          if (labelChild && typeof node.props?.className === 'string' && node.props.className.includes('we-picker__slider-row')) {
+            const inp = children.find((c) => c && typeof c === 'object' && c.type === 'input');
+            if (inp && typeof inp.props.onInput === 'function') input = inp;
+          }
+          if (Array.isArray(node.children)) node.children.forEach(walk);
+        })(tree);
+        if (!input) return null;
+        input.props.onInput({ target: { value: String(value) } });
+        tree = pickerRenders[0]();
+        let after = null;
+        (function walk(node) {
+          if (Array.isArray(node)) { node.forEach(walk); return; }
+          if (!node || typeof node !== 'object') return;
+          const children = Array.isArray(node.children) ? node.children : [];
+          const labelChild = children.find((c) => c && typeof c === 'object' && Array.isArray(c.children) && c.children.includes(label));
+          if (labelChild && typeof node.props?.className === 'string' && node.props.className.includes('we-picker__slider-row')) {
+            const inp = children.find((c) => c && typeof c === 'object' && c.type === 'input');
+            if (inp) after = inp;
+          }
+          if (Array.isArray(node.children)) node.children.forEach(walk);
+        })(tree);
+        return after ? after.props.value : null;
+      };
+      console.log('侧栏模糊 拖到 80 后保持 (expect 80):', dragSidebarSlider('侧栏模糊', 80));
+      console.log('内容面透明度 拖到 70 后保持 (expect 70):', dragSidebarSlider('内容面透明度', 70));
       console.log('whole-window glass master switch present:', treeText.includes('设置窗口液态玻璃'));
       console.log('window glass hint present:', treeText.includes('整个设置窗口'));
       // The thumbnail grid lives inside the picker MODAL now (settings page

--- a/src/client.js
+++ b/src/client.js
@@ -2745,13 +2745,20 @@ const CSS = `
   body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
   body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
     background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.66 * 100%), transparent) !important;
-    background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.04) 38%, rgba(255, 255, 255, 0.01)) !important;
+    /* Specular sheen + refraction highlights SCALE with --we-sidebar-alpha
+       (coefficients keep the 12% default look identical: 0.626*0.2236≈0.14,
+       1.43*0.2236≈0.32 …). At 100% transparency the white glaze fades out too,
+       so the sidebar is truly near-transparent instead of pale white. */
+    background-image: linear-gradient(180deg,
+      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.626)),
+      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.179)) 38%,
+      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.045))) !important;
     -webkit-backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
     backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, var(--we-glass-highlight, 0.32)),
-      inset 0 -1px 0 rgba(255, 255, 255, 0.08),
-      inset 0 0 0 0.5px rgba(255, 255, 255, 0.06);
+      inset 0 1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 1.43)),
+      inset 0 -1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.358)),
+      inset 0 0 0 0.5px rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.268));
   }
   body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
   body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],

--- a/src/client.js
+++ b/src/client.js
@@ -1439,9 +1439,17 @@ function applyEffects() {
   s.setProperty("--we-sidebar-blur", selection.sidebarBlur + "px");
   // 饱和度随模糊增长但封顶（blur 最大 100px 时 1.15+2.8=3.95 过于夸张）。
   s.setProperty("--we-sidebar-saturate", String(Math.min(3.2, 1.15 + selection.sidebarBlur * 0.028)));
-  // 透明度 0–100 全范围映射：0 → 0.25（近实色），100 → 0.03（接近全透）。
-  const sidebarAlpha = Math.max(0.03, 0.25 - (selection.sidebarAlpha / 100) * 0.22);
+  // 透明度 0–100 全范围映射：0 → 0.9（近实色），12%（默认）→ 0.2236（保持
+  // 既有观感不变），100 → 0.03（近全透）。分段线性以默认值为拐点——旧的
+  // 0.25 上限在 0% 时只有 16.5% 白（壁纸几乎全透出，实测"0% 也极其透明"）。
+  // sheen 因子 = min(1, alpha/0.2236)：比默认更实时维持原设计高光强度，
+  // 只有往透明方向衰减（100% 时白色釉面随之消失）。
+  const sidebarAlphaPct = selection.sidebarAlpha;
+  const sidebarAlpha = sidebarAlphaPct <= 12
+    ? 0.9 - (sidebarAlphaPct / 12) * (0.9 - 0.2236)
+    : 0.2236 - ((sidebarAlphaPct - 12) / 88) * (0.2236 - 0.03);
   s.setProperty("--we-sidebar-alpha", String(sidebarAlpha));
+  s.setProperty("--we-sidebar-sheen", String(Math.min(1, sidebarAlpha / 0.2236)));
   s.setProperty("--we-sidebar-color", selection.sidebarColor);
   if (selection.sidebarGlass) document.body.setAttribute("data-we-sidebar-glass", "on");
   else document.body.removeAttribute("data-we-sidebar-glass");
@@ -1487,6 +1495,7 @@ function clearEffects() {
   s.removeProperty("--we-sidebar-blur");
   s.removeProperty("--we-sidebar-saturate");
   s.removeProperty("--we-sidebar-alpha");
+  s.removeProperty("--we-sidebar-sheen");
   s.removeProperty("--we-sidebar-color");
   document.body.removeAttribute("data-we-sidebar-glass");
   s.removeProperty("--we-content-surface-alpha");
@@ -2745,20 +2754,21 @@ const CSS = `
   body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_boundaryError"],
   body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_panel"] {
     background-color: color-mix(in srgb, var(--we-sidebar-color, #ffffff) calc(var(--we-sidebar-alpha, 0.15) * 0.66 * 100%), transparent) !important;
-    /* Specular sheen + refraction highlights SCALE with --we-sidebar-alpha
-       (coefficients keep the 12% default look identical: 0.626*0.2236≈0.14,
-       1.43*0.2236≈0.32 …). At 100% transparency the white glaze fades out too,
-       so the sidebar is truly near-transparent instead of pale white. */
+    /* Specular sheen + refraction highlights follow --we-sidebar-sheen
+       (= min(1, alpha/0.2236)): at default (12%) and any MORE solid setting
+       the sheen keeps the ORIGINAL design strength (0.14/0.04/0.01,
+       0.32/0.08/0.06); only toward transparency does the white glaze fade,
+       so 100% is truly near-transparent instead of pale white. */
     background-image: linear-gradient(180deg,
-      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.626)),
-      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.179)) 38%,
-      rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.045))) !important;
+      rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.14)),
+      rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.04)) 38%,
+      rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.01))) !important;
     -webkit-backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
     backdrop-filter: blur(var(--we-sidebar-blur, 16px)) saturate(var(--we-sidebar-saturate, 1.8)) brightness(var(--we-glass-brightness, 1.04)) contrast(1.01) !important;
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 1.43)),
-      inset 0 -1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.358)),
-      inset 0 0 0 0.5px rgba(255, 255, 255, calc(var(--we-sidebar-alpha, 0.15) * 0.268));
+      inset 0 1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.32)),
+      inset 0 -1px 0 rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.08)),
+      inset 0 0 0 0.5px rgba(255, 255, 255, calc(var(--we-sidebar-sheen, 1) * 0.06));
   }
   body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_pane"],
   body[data-we-sidebar-glass][data-we-wallpaper] [data-dsh-better-sidebar] [class*="_tabBar"],

--- a/src/client.js
+++ b/src/client.js
@@ -141,7 +141,7 @@ const DEFAULTS = {
   // 内容面（编辑器/终端）近不透明玻璃底的细调——既有固定调色板（语法高亮/
   // ANSI）为不透明底设计，全透明毛玻璃下注释灰不可读，全不透明又失去玻璃感：
   // - sidebarContentAlpha：内容面透明度（%），越大越透（映射到底色不透明度
-  //   100%→50%；默认 30 → 70% 不透明，亮/暗主题实测显示均合理，玻璃感与
+  //   100%→20%；默认 30 → 70% 不透明，亮/暗主题实测显示均合理，玻璃感与
   //   注释可读性平衡）；
   // - sidebarContentColor：内容面底色（#rrggbb），空 = 跟随主题面板色
   //   (--dsw-alias-bg-layer-1)，选定后双主题统一使用该色。
@@ -248,11 +248,11 @@ function sanitizeSettings(o) {
       ? o.glassColor : DEFAULTS.glassColor,
     glassWindow: o.glassWindow !== false,
     sidebarGlass: o.sidebarGlass !== false,
-    sidebarBlur: clampNum(o.sidebarBlur, 0, 60, DEFAULTS.sidebarBlur),
-    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, DEFAULTS.sidebarAlpha),
+    sidebarBlur: clampNum(o.sidebarBlur, 0, 100, DEFAULTS.sidebarBlur),
+    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 100, DEFAULTS.sidebarAlpha),
     sidebarColor: typeof o.sidebarColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
       ? o.sidebarColor : DEFAULTS.sidebarColor,
-    sidebarContentAlpha: clampNum(o.sidebarContentAlpha, 0, 50, DEFAULTS.sidebarContentAlpha),
+    sidebarContentAlpha: clampNum(o.sidebarContentAlpha, 0, 80, DEFAULTS.sidebarContentAlpha),
     sidebarContentColor: typeof o.sidebarContentColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarContentColor)
       ? o.sidebarContentColor : DEFAULTS.sidebarContentColor,
   };
@@ -1437,17 +1437,20 @@ function applyEffects() {
   // 侧栏透明度 / 侧栏玻璃颜色 + 总开关）。变量只作用于 [data-dsh-better-sidebar]
   // 子树（CSS 见下），关闭总开关时侧栏恢复原生外观。
   s.setProperty("--we-sidebar-blur", selection.sidebarBlur + "px");
-  s.setProperty("--we-sidebar-saturate", String(1.15 + selection.sidebarBlur * 0.028));
-  const sidebarAlpha = Math.max(0.03, 0.25 - (selection.sidebarAlpha / 60) * 0.22);
+  // 饱和度随模糊增长但封顶（blur 最大 100px 时 1.15+2.8=3.95 过于夸张）。
+  s.setProperty("--we-sidebar-saturate", String(Math.min(3.2, 1.15 + selection.sidebarBlur * 0.028)));
+  // 透明度 0–100 全范围映射：0 → 0.25（近实色），100 → 0.03（接近全透）。
+  const sidebarAlpha = Math.max(0.03, 0.25 - (selection.sidebarAlpha / 100) * 0.22);
   s.setProperty("--we-sidebar-alpha", String(sidebarAlpha));
   s.setProperty("--we-sidebar-color", selection.sidebarColor);
   if (selection.sidebarGlass) document.body.setAttribute("data-we-sidebar-glass", "on");
   else document.body.removeAttribute("data-we-sidebar-glass");
-  // 内容面（编辑器/终端）近不透明玻璃底：透明度滑块 0–50 → 不透明度 100%–50%
-  // （越大越透，与玻璃透明度同语义）；底色空 = 跟随主题面板色，选定后自定义。
+  // 内容面（编辑器/终端）近不透明玻璃底：透明度滑块 0–80 → 不透明度 100%–20%
+  // （越大越透，与玻璃透明度同语义；低于 ~40% 不透明度注释可读性会再次变差，
+  // 留给用户自行权衡）；底色空 = 跟随主题面板色，选定后自定义。
   // 注意 color-mix 的百分比槽位要求带单位的 token —— 变量值必须含 "%"，
   // 否则整个 color-mix 失效、底色规则被丢弃（编辑器回退到纯透明毛玻璃）。
-  s.setProperty("--we-content-surface-alpha", Math.max(50, 100 - selection.sidebarContentAlpha) + "%");
+  s.setProperty("--we-content-surface-alpha", Math.max(20, 100 - selection.sidebarContentAlpha) + "%");
   if (selection.sidebarContentColor) s.setProperty("--we-content-surface-color", selection.sidebarContentColor);
   else s.removeProperty("--we-content-surface-color");
 
@@ -1647,11 +1650,11 @@ function WallpaperPicker() {
   // 侧栏玻璃（dsh-better-sidebar）：独立于会话玻璃的一套细粒度控制，各自立即
   // 生效并持久化（--we-sidebar-blur / --we-sidebar-alpha / --we-sidebar-color）。
   const onSidebarBlur = (px) => {
-    selection.sidebarBlur = clampNum(px, 0, 60, DEFAULTS.sidebarBlur);
+    selection.sidebarBlur = clampNum(px, 0, 100, DEFAULTS.sidebarBlur);
     persistSelection(); applyEffects(); emit();
   };
   const onSidebarAlpha = (pct) => {
-    selection.sidebarAlpha = clampNum(pct, 0, 60, DEFAULTS.sidebarAlpha);
+    selection.sidebarAlpha = clampNum(pct, 0, 100, DEFAULTS.sidebarAlpha);
     persistSelection(); applyEffects(); emit();
   };
   const onSidebarColor = (hex) => {
@@ -1661,7 +1664,7 @@ function WallpaperPicker() {
   };
   // 内容面（编辑器/终端）近不透明玻璃底：透明度滑块 + 底色（空 = 跟随主题）。
   const onSidebarContentAlpha = (pct) => {
-    selection.sidebarContentAlpha = clampNum(pct, 0, 50, DEFAULTS.sidebarContentAlpha);
+    selection.sidebarContentAlpha = clampNum(pct, 0, 80, DEFAULTS.sidebarContentAlpha);
     persistSelection(); applyEffects(); emit();
   };
   const onSidebarContentColor = (hex) => {
@@ -1871,8 +1874,8 @@ function WallpaperPicker() {
       ),
       ],
       sel.sidebarPresent && sel.sidebarGlass && [
-      SliderRow("侧栏模糊", 0, 60, 1, sel.sidebarBlur, onSidebarBlur, sel.sidebarBlur + "px"),
-      SliderRow("侧栏透明度", 0, 60, 5, sel.sidebarAlpha, onSidebarAlpha, sel.sidebarAlpha + "%"),
+      SliderRow("侧栏模糊", 0, 100, 1, sel.sidebarBlur, onSidebarBlur, sel.sidebarBlur + "px"),
+      SliderRow("侧栏透明度", 0, 100, 5, sel.sidebarAlpha, onSidebarAlpha, sel.sidebarAlpha + "%"),
       React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
         React.createElement("span", { className: "we-picker__hint we-picker__label" }, "侧栏玻璃颜色"),
         GLASS_COLOR_PRESETS.map((hex) => React.createElement("button", {
@@ -1898,7 +1901,7 @@ function WallpaperPicker() {
       // 内容面（编辑器 / 终端）近不透明玻璃底：透明度 + 底色。固定调色板
       // （语法高亮 / ANSI）为不透明底设计，全透毛玻璃下注释灰不可读；这里
       // 在"玻璃感"与"可读性"之间取平衡——透明度越大越透，底色空 = 跟随主题。
-      SliderRow("内容面透明度", 0, 50, 5, sel.sidebarContentAlpha, onSidebarContentAlpha, sel.sidebarContentAlpha + "%"),
+      SliderRow("内容面透明度", 0, 80, 5, sel.sidebarContentAlpha, onSidebarContentAlpha, sel.sidebarContentAlpha + "%"),
       React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
         React.createElement("span", { className: "we-picker__hint we-picker__label" }, "内容面底色"),
         React.createElement("button", {

--- a/src/client.js
+++ b/src/client.js
@@ -138,6 +138,15 @@ const DEFAULTS = {
   sidebarBlur: 16,
   sidebarAlpha: 12,
   sidebarColor: "#ffffff",
+  // 内容面（编辑器/终端）近不透明玻璃底的细调——既有固定调色板（语法高亮/
+  // ANSI）为不透明底设计，全透明毛玻璃下注释灰不可读，全不透明又失去玻璃感：
+  // - sidebarContentAlpha：内容面透明度（%），越大越透（映射到底色不透明度
+  //   100%→50%；默认 30 → 70% 不透明，亮/暗主题实测显示均合理，玻璃感与
+  //   注释可读性平衡）；
+  // - sidebarContentColor：内容面底色（#rrggbb），空 = 跟随主题面板色
+  //   (--dsw-alias-bg-layer-1)，选定后双主题统一使用该色。
+  sidebarContentAlpha: 30,
+  sidebarContentColor: "",
 };
 
 // Selectable values for the two filters. Declared up top because
@@ -243,6 +252,9 @@ function sanitizeSettings(o) {
     sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, DEFAULTS.sidebarAlpha),
     sidebarColor: typeof o.sidebarColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
       ? o.sidebarColor : DEFAULTS.sidebarColor,
+    sidebarContentAlpha: clampNum(o.sidebarContentAlpha, 0, 50, DEFAULTS.sidebarContentAlpha),
+    sidebarContentColor: typeof o.sidebarContentColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarContentColor)
+      ? o.sidebarContentColor : DEFAULTS.sidebarContentColor,
   };
 }
 
@@ -349,6 +361,8 @@ function serializeSelection() {
     sidebarBlur: selection.sidebarBlur,
     sidebarAlpha: selection.sidebarAlpha,
     sidebarColor: selection.sidebarColor,
+    sidebarContentAlpha: selection.sidebarContentAlpha,
+    sidebarContentColor: selection.sidebarContentColor,
   };
 }
 
@@ -1429,6 +1443,13 @@ function applyEffects() {
   s.setProperty("--we-sidebar-color", selection.sidebarColor);
   if (selection.sidebarGlass) document.body.setAttribute("data-we-sidebar-glass", "on");
   else document.body.removeAttribute("data-we-sidebar-glass");
+  // 内容面（编辑器/终端）近不透明玻璃底：透明度滑块 0–50 → 不透明度 100%–50%
+  // （越大越透，与玻璃透明度同语义）；底色空 = 跟随主题面板色，选定后自定义。
+  // 注意 color-mix 的百分比槽位要求带单位的 token —— 变量值必须含 "%"，
+  // 否则整个 color-mix 失效、底色规则被丢弃（编辑器回退到纯透明毛玻璃）。
+  s.setProperty("--we-content-surface-alpha", Math.max(50, 100 - selection.sidebarContentAlpha) + "%");
+  if (selection.sidebarContentColor) s.setProperty("--we-content-surface-color", selection.sidebarContentColor);
+  else s.removeProperty("--we-content-surface-color");
 
   // Scrim immediacy: some composited/kiosk environments do not repaint a
   // z-index:-1 layer promptly when only an inherited CSS variable changes.
@@ -1465,6 +1486,8 @@ function clearEffects() {
   s.removeProperty("--we-sidebar-alpha");
   s.removeProperty("--we-sidebar-color");
   document.body.removeAttribute("data-we-sidebar-glass");
+  s.removeProperty("--we-content-surface-alpha");
+  s.removeProperty("--we-content-surface-color");
   const scrim = document.getElementById(SCRIM_ID);
   if (scrim) scrim.style.background = "";
 }
@@ -1634,6 +1657,21 @@ function WallpaperPicker() {
   const onSidebarColor = (hex) => {
     if (!/^#[0-9a-f]{6}$/i.test(hex)) return;
     selection.sidebarColor = hex;
+    persistSelection(); applyEffects(); emit();
+  };
+  // 内容面（编辑器/终端）近不透明玻璃底：透明度滑块 + 底色（空 = 跟随主题）。
+  const onSidebarContentAlpha = (pct) => {
+    selection.sidebarContentAlpha = clampNum(pct, 0, 50, DEFAULTS.sidebarContentAlpha);
+    persistSelection(); applyEffects(); emit();
+  };
+  const onSidebarContentColor = (hex) => {
+    if (hex === "") {
+      selection.sidebarContentColor = ""; // 跟随主题面板色
+      persistSelection(); applyEffects(); emit();
+      return;
+    }
+    if (!/^#[0-9a-f]{6}$/i.test(hex)) return;
+    selection.sidebarContentColor = hex;
     persistSelection(); applyEffects(); emit();
   };
 
@@ -1853,6 +1891,39 @@ function WallpaperPicker() {
             onInput: (e) => onSidebarColor(e.target.value),
             onChange: (e) => onSidebarColor(e.target.value),
             title: "自定义侧栏玻璃颜色",
+          }),
+          React.createElement("span", { className: "we-picker__hint" }, "自定义"),
+        ),
+      ),
+      // 内容面（编辑器 / 终端）近不透明玻璃底：透明度 + 底色。固定调色板
+      // （语法高亮 / ANSI）为不透明底设计，全透毛玻璃下注释灰不可读；这里
+      // 在"玻璃感"与"可读性"之间取平衡——透明度越大越透，底色空 = 跟随主题。
+      SliderRow("内容面透明度", 0, 50, 5, sel.sidebarContentAlpha, onSidebarContentAlpha, sel.sidebarContentAlpha + "%"),
+      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "内容面底色"),
+        React.createElement("button", {
+          className: "we-picker__swatch we-picker__swatch--auto" + (sel.sidebarContentColor === "" ? " we-picker__swatch--active" : ""),
+          type: "button",
+          title: "跟随主题面板色",
+          onClick: () => onSidebarContentColor(""),
+          "aria-label": "内容面底色 跟随主题",
+        }, "主题"),
+        GLASS_COLOR_PRESETS.map((hex) => React.createElement("button", {
+          key: hex,
+          className: "we-picker__swatch" + (sel.sidebarContentColor === hex ? " we-picker__swatch--active" : ""),
+          type: "button",
+          style: { background: hex },
+          title: hex,
+          onClick: () => onSidebarContentColor(hex),
+          "aria-label": "内容面底色 " + hex,
+        })),
+        React.createElement("label", { className: "we-picker__swatch-custom" },
+          React.createElement("input", {
+            type: "color",
+            value: sel.sidebarContentColor || "#1e1f26",
+            onInput: (e) => onSidebarContentColor(e.target.value),
+            onChange: (e) => onSidebarContentColor(e.target.value),
+            title: "自定义内容面底色",
           }),
           React.createElement("span", { className: "we-picker__hint" }, "自定义"),
         ),
@@ -2723,6 +2794,28 @@ const CSS = `
     }
   }
 
+  /* ── dsh-better-sidebar CONTENT surfaces: near-opaque tinted glass ─────────
+     The editor (CodeMirror) surface is transparent by design, and the terminal
+     background reads --dsw-alias-bg-base — which we must keep transparent so
+     the wallpaper shows through. Their fixed content palettes (syntax
+     highlighting / ANSI colors) are designed for an OPAQUE backdrop (One
+     Dark/Light, xterm themes): on the fully frosted composite the mid-gray
+     comments etc. lose all contrast (实测注释灰 1.7–2.3:1，看不清).
+     Fully opaque surfaces fix readability but kill the glass look. Balance:
+     a NEAR-OPAQUE TINTED glass plate — the theme's opaque panel color
+     (--dsw-alias-bg-layer-1) at 88% keeps the wallpaper glow bleeding through
+     (still reads as glass) while the composite stays dark/light enough for the
+     the designed content palettes. Tune via the 内容面透明度 / 内容面底色 controls
+     (--we-content-surface-alpha / --we-content-surface-color; color empty =
+     follow the theme panel color). Gated on data-we-wallpaper, NOT the
+     sidebar-glass switch — the terminal turns transparent even with the switch
+     off. .cm-editor / .xterm are library-global class names (stable across the
+     sidebar's builds). */
+  body[data-we-wallpaper] [data-dsh-better-sidebar] .cm-editor,
+  body[data-we-wallpaper] [data-dsh-better-sidebar] .xterm {
+    background-color: color-mix(in srgb, var(--we-content-surface-color, var(--dsw-alias-bg-layer-1, #1e1f26)) var(--we-content-surface-alpha, 88%), transparent) !important;
+  }
+
   /* Picker chrome. */
   .we-picker { display: flex; flex-direction: column; gap: 10px; }
   .we-picker__select { max-width: 100%; }
@@ -2870,6 +2963,14 @@ const CSS = `
   .we-picker__swatch:hover { transform: scale(1.12); }
   .we-picker__swatch--active {
     box-shadow: 0 0 0 2px var(--we-accent, #4f8cff), 0 0 0 4px rgba(255, 255, 255, 0.5);
+  }
+  /* "跟随主题" auto swatch (内容面底色): no fill, split ring showing both
+     themes so it reads as "use the theme panel color". */
+  .we-picker__swatch--auto {
+    font-size: 10px; line-height: 1; font-weight: 600;
+    color: var(--dsw-alias-label-secondary, #666);
+    background: linear-gradient(135deg, #2a2d35 0 50%, #f2f3f5 50% 100%);
+    display: inline-flex; align-items: center; justify-content: center;
   }
   .we-picker__swatch-custom {
     display: inline-flex; align-items: center; gap: 4px; cursor: pointer;


### PR DESCRIPTION
## 动机

better-sidebar 的编辑器（CodeMirror）内容表面设计为 transparent，终端背景读取
`--dsw-alias-bg-base`（壁纸插件为露出壁纸将其置为 transparent）。壁纸激活后，
这两个内容表面直接叠在毛玻璃复合底上，而为不透明底设计的固定调色板（语法高亮 /
ANSI）里的注释灰等颜色对比度崩塌（实测 1.7–2.3:1），亮/暗主题下都看不清。

## 改动

- 壁纸激活时给 `.cm-editor` / `.xterm`（CodeMirror/xterm 的库级全局类名，跨侧栏
  版本稳定）近不透明彩色玻璃底：`color-mix(主题面板色 70%, transparent)` ——
  保留壁纸色调透入的玻璃感，同时恢复调色板设计底的可读性；语法色 / ANSI 调色板
  一个不动；
- 新增两个配置项（随「侧栏液态玻璃」开关显示，与侧栏模糊/透明度/玻璃颜色同级）：
  - **内容面透明度**（`sidebarContentAlpha`，0–50%，默认 30 → 70% 不透明度，
    亮/暗主题实测显示合理）；
  - **内容面底色**（`sidebarContentColor`，空 = 跟随主题面板色，可选色板/自定义）；
- 宿主 sanitize 镜像同步新字段（跨重启持久化）。

## 测试

verify-client 新增断言：两个控制项渲染与「侧栏液态玻璃」开关联动（关闭隐藏、
开启恢复）；`--we-content-surface-alpha` 必须以 "%" 结尾（color-mix 百分比槽位的
回归防护——无单位数字会使整条 background-color 规则静默失效，此前实测踩过）。

## 验证步骤

1. `npm run build && npm run verify`
2. 壁纸激活 + 侧栏液态玻璃开启，打开编辑器和终端：
   - 默认 30% 透明度下注释/语法色清晰，壁纸色调有浅浅透入；
   - 调节「内容面透明度」「内容面底色」实时生效；
   - 亮/暗主题各看一眼。
   
  ##效果图
  
<img width="720" height="1473" alt="image" src="https://github.com/user-attachments/assets/38b1565c-5057-4698-895b-ac46935261e1" />
<img width="1874" height="1221" alt="image" src="https://github.com/user-attachments/assets/12bc7d4b-7796-4cd7-86c7-571fda66a786" />
