### PR TITLE
fix: upload remove/dedup path containment is separator-agnostic (macO…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ import {
 // event loop responsive on slow media (WSL DrvFS) instead of blocking it for
 // seconds per chunk (see "Loading plugins…" stall report).
 import { access, readdir, readFile, stat } from 'node:fs/promises';
-import { join, resolve, normalize, basename, dirname } from 'node:path';
+import { join, resolve, normalize, basename, dirname, relative, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { execFileSync, spawn } from 'node:child_process';
@@ -1232,7 +1232,14 @@ function resolveUploadFile(dir, id) {
       const m = UPLOAD_FILE_RE.exec(entry);
       if (m && m[1].toLowerCase() === id.toLowerCase()) {
         const abs = normalize(join(dir, entry));
-        if (abs.startsWith(root + '\\')) return abs; // stays inside uploads dir
+        // Containment check that is NOT tied to the Windows separator: the old
+        // `abs.startsWith(root + '\\')` never matched on macOS/Linux (where
+        // normalize yields '/'), so removing (and deduping) uploads always
+        // failed with "invalid upload id" there. path.relative is separator-
+        // agnostic AND survives edge roots (uploads dir = '/' or a drive root,
+        // where naive separator concatenation also breaks).
+        const rel = relative(root, abs);
+        if (rel && !rel.startsWith('..') && !isAbsolute(rel)) return abs; // stays inside uploads dir
       }
     }
   } catch { /* ignore */ }


### PR DESCRIPTION
## 问题描述

「自定义壁纸」区域点击「移除」并确认后报错：**移除失败：invalid upload id**。
macOS / Linux 上所有上传的移除都失败；Windows 正常。

## 根因

`resolveUploadFile()`（`lib/index.js`）的路径包含性检查硬编码了 Windows 分隔符：

```js
if (abs.startsWith(root + '\\')) return abs; // stays inside uploads dir
```

macOS / Linux 上 `path.normalize()` 产生的是 `/` 分隔符，`root + '\\'` 永远不匹配，
于是 `resolveUploadFile()` 对所有上传 id 都返回 `null`，服务端随即返回
400 `invalid upload id`。

## 影响范围（较 issue 描述更广）

- **移除**：必然失败（400），如问题描述；
- **上传去重**（`/upload` 的 sha256 去重路径，同样调用 `resolveUploadFile`）：
  **静默失效**——重复上传不会被识别为重复，而是另存一份新文件（不报错，但失去去重）；
- 列表、上传本体不受影响（不走该函数）。

## 修复

改用 `path.relative` 做包含性检查——分隔符无关，且顺带覆盖字符串拼接同样会失效
的边界（上传目录本身是 `/` 或盘符根目录，如 `C:\`）：

```js
import { join, resolve, normalize, basename, dirname, relative, isAbsolute } from 'node:path';
...
const rel = relative(root, abs);
if (rel && !rel.startsWith('..') && !isAbsolute(rel)) return abs; // stays inside uploads dir
```

## 测试

包含性逻辑用 Node 的 win32 / posix 两套 path 实现各验证 4 项，共 8 项全过：
- 常规：目录内命中 / 目录外拒绝；
- 边界：根目录为 `/`（POSIX）或盘符根 `C:\`（Windows）时命中；
- 逃逸：`..` 相对路径拒绝；
- Windows 跨盘（`C:` → `D:`）拒绝。

## 验证步骤

1. `node --check lib/index.js`
2. macOS / Linux：上传一张壁纸 → 列表可见 → 「移除」确认 → 不再报
   `invalid upload id`，文件被删除；
3. 上传同一文件两次 → 第二次返回 `duplicate: true`（去重恢复）；
4. Windows 回归：移除 / 去重行为与之前一致。