### PR TITLE
feat: detect Steam root via Windows registry from WSL + DSH_WE_STEAM_ROOT fallback

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -404,6 +404,7 @@ files** (in the directory you chose) and `~/.dsh-wallpaper-engine/config.json`
 | `DSH_WE_FFMPEG` | explicit ffmpeg executable path (highest priority in the resolution chain) |
 | `DSH_WE_FFMPEG_URL` | replaces the auto-download source (self-hosted mirror / proxy) |
 | `DSH_WE_CACHE_DIR` | overrides the cache root (transcode cache / scene-frame cache) |
+| `DSH_WE_STEAM_ROOT` | explicit Steam root(s) (comma/semicolon separated, Windows or /mnt paths; fallback when registry/auto-detection misses) |
 
 ## dsh-better-sidebar compatibility
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ dsh plugin --profile web add link:./dsh-wallpaper-engine
 | `DSH_WE_FFMPEG` | 指定 ffmpeg 可执行文件（解析链最高优先） |
 | `DSH_WE_FFMPEG_URL` | 替换自动下载源（自建镜像 / 代理加速） |
 | `DSH_WE_CACHE_DIR` | 覆盖缓存根目录（抽帧转码缓存 / 场景静态帧缓存） |
+| `DSH_WE_STEAM_ROOT` | 显式指定 Steam 根目录（逗号/分号分隔，Windows 或 `/mnt` 路径；注册表/自动探测失效时的兜底） |
 
 ## 与 dsh-better-sidebar 的兼容适配
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,19 +66,63 @@ const STEAM_PROBE_DIRS = [
   'E:\\SteamLibrary',
 ];
 
-/** Steam root recorded by the Windows installer; the probe list misses custom dirs. */
-function steamPathFromRegistry() {
-  if (process.platform !== 'win32') return null;
+/**
+ * Locate a usable reg.exe: the SystemRoot copy on Windows, or a mounted
+ * Windows System32 under /mnt/<letter> on WSL (DrvFS). Returns null on every
+ * other platform — plain Linux/macOS have no Windows registry to query, so the
+ * probe is a safe no-op there (no /mnt drive letter → nothing found).
+ */
+async function resolveRegExeP() {
+  if (process.platform === 'win32') {
+    return join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'reg.exe');
+  }
+  if (process.platform !== 'linux') return null;
+  let letters = [];
+  try { letters = (await readdir('/mnt')).filter((n) => /^[a-zA-Z]$/.test(n)); } catch { return null; }
+  for (const letter of letters) {
+    const p = join('/mnt', letter, 'Windows', 'System32', 'reg.exe');
+    if (await pathExistsP(p)) return p;
+  }
+  return null;
+}
+
+/**
+ * Steam root recorded by the Windows installer; the fixed probe list misses
+ * custom dirs (e.g. `D:\Game\Steam`). Works on Windows (native reg.exe) AND on
+ * WSL (the Windows copy under /mnt/<letter>), so custom Steam directories are
+ * found on both. The returned Windows path is translated to its /mnt form on
+ * WSL so downstream probing resolves on the Linux side. On any other Linux the
+ * reg.exe probe finds nothing and this returns null — same as before.
+ */
+async function steamPathFromRegistry() {
+  const reg = await resolveRegExeP();
+  if (!reg) return null;
   try {
-    const reg = join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'reg.exe');
     const out = execFileSync(
       reg,
       ['query', 'HKCU\\Software\\Valve\\Steam', '/v', 'SteamPath'],
       { encoding: 'utf8', windowsHide: true, timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] },
     );
     const m = /SteamPath\s+REG_SZ\s+(.+)/i.exec(out);
-    return m ? normalize(m[1].trim()) : null;
+    const p = m ? normalize(m[1].trim()) : null;
+    return p ? wslPath(p) : null;
   } catch { return null; }
+}
+
+/**
+ * Explicit Steam-root override(s) from DSH_WE_STEAM_ROOT (comma/semicolon
+ * separated). Covers Steam installs the registry/probe list cannot reach —
+ * e.g. `D:\Game\Steam` or, from WSL, `/mnt/d/Game/Steam`. Entries run through
+ * wslPath so a Windows-style value works when the harness runs inside WSL.
+ */
+function steamRootsFromEnv() {
+  const raw = process.env.DSH_WE_STEAM_ROOT && process.env.DSH_WE_STEAM_ROOT.trim();
+  if (!raw) return [];
+  return raw
+    .split(/[,;]/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(wslPath);
 }
 
 /** Async existence probes (fs.promises — thread pool, no event-loop blocking). */
@@ -116,11 +160,12 @@ async function wslSteamRootsP() {
   return roots;
 }
 
-/** Probe list: registry root first, then known dirs, then WSL /mnt mounts. */
+/** Probe list: registry root, env override(s), known dirs, then WSL /mnt mounts. */
 async function steamProbeDirsP() {
-  const reg = steamPathFromRegistry();
+  const reg = await steamPathFromRegistry();
+  const env = steamRootsFromEnv();
   const wsl = await wslSteamRootsP();
-  return [...(reg ? [reg] : []), ...STEAM_PROBE_DIRS, ...wsl];
+  return [...(reg ? [reg] : []), ...env, ...STEAM_PROBE_DIRS, ...wsl];
 }
 
 /**


### PR DESCRIPTION
Closes #40

## 问题

WSL 下无法检测自定义目录安装的 Wallpaper Engine。`wslSteamRootsP()` 只探测每个挂载盘的 4 个标准 Steam 目录，且 `steamPathFromRegistry()` 用 `process.platform !== 'win32'` 在 WSL（Linux）下直接跳过注册表通道——Steam 装在 `D:\Game\Steam` 这类自定义目录时全部落空。

## 改动

`lib/index.js`（host 端，+53/-8，无需重新构建）：

- **WSL 注册表通道（方案 A）**：新增 `resolveRegExeP()`，在 WSL 下探测 `/mnt/<盘>/Windows/System32/reg.exe` 并读取 `HKCU\Software\Valve\Steam\SteamPath`；结果经 `wslPath()` 转 `/mnt` 路径。拿到 Steam 根目录后，现有 `libraryfolders.vdf` 解析链自动跳转到任意库盘（本机实测：D 盘注册表根 → E 盘 WE 安装）。
- **环境变量兜底（方案 B）**：`DSH_WE_STEAM_ROOT`（逗号/分号分隔，Windows 或 `/mnt` 路径）。
- 非 WSL Linux/macOS 不受影响：reg.exe 探测只在 `/mnt/<盘符>/Windows/System32` 下查找，普通 Linux 无此路径 → 返回 null，行为与之前完全一致。

## 验证（WSL2 真实环境）

- `resolveRegExeP` → `/mnt/c/Windows/System32/reg.exe`（注册表读取 exit=0，无需授权）
- `steamPathFromRegistry` → `/mnt/d/game/steam`
- `locateWallpaperEngineP` → `/mnt/e/Game/Steam/steamapps/common/wallpaper_engine`
- `owningLibrariesP` → `['/mnt/e/Game/Steam']`
- 库存枚举：97 个壁纸（32 video / 60 scene / 5 web）
- `DSH_WE_STEAM_ROOT` 单值/多值/Windows 形式均通过

## 文档

README / README.en 环境变量表各加 1 行 `DSH_WE_STEAM_ROOT`。