### PR TITLE
feat: detect Steam root via Windows registry from WSL + DSH_WE_STEAM_ROOT fallback

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -410,6 +410,7 @@ files** (in the directory you chose) and `~/.dsh-wallpaper-engine/config.json`
 | `DSH_WE_FFMPEG` | explicit ffmpeg executable path (highest priority in the resolution chain) |
 | `DSH_WE_FFMPEG_URL` | replaces the auto-download source (self-hosted mirror / proxy) |
 | `DSH_WE_CACHE_DIR` | overrides the cache root (transcode cache / scene-frame cache) |
+| `DSH_WE_STEAM_ROOT` | explicit Steam root(s) (comma/semicolon separated, Windows or /mnt paths; fallback when registry/auto-detection misses) |
 
 ## dsh-better-sidebar compatibility
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ dsh plugin --profile web add link:./dsh-wallpaper-engine
 | `DSH_WE_FFMPEG` | 指定 ffmpeg 可执行文件（解析链最高优先） |
 | `DSH_WE_FFMPEG_URL` | 替换自动下载源（自建镜像 / 代理加速） |
 | `DSH_WE_CACHE_DIR` | 覆盖缓存根目录（抽帧转码缓存 / 场景静态帧缓存） |
+| `DSH_WE_STEAM_ROOT` | 显式指定 Steam 根目录（逗号/分号分隔，Windows 或 `/mnt` 路径；注册表/自动探测失效时的兜底） |
 
 ## 与 dsh-better-sidebar 的兼容适配
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,26 +79,53 @@ const STEAM_PROBE_DIRS = [
   'E:\\SteamLibrary',
 ];
 
-/** Steam root recorded by the Windows installer; the probe list misses custom dirs. */
+/** reg.exe: SystemRoot on Windows, /mnt/<letter>/Windows/System32 on WSL; null elsewhere. */
+async function resolveRegExeP() {
+  if (process.platform === 'win32') {
+    return join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'reg.exe');
+  }
+  if (process.platform !== 'linux') return null;
+  let letters = [];
+  try { letters = (await readdir('/mnt')).filter((n) => /^[a-zA-Z]$/.test(n)); } catch { return null; }
+  for (const letter of letters) {
+    const p = join('/mnt', letter, 'Windows', 'System32', 'reg.exe');
+    if (await pathExistsP(p)) return p;
+  }
+  return null;
+}
+
+/** Steam root from HKCU\\Software\\Valve\\Steam on Windows and WSL; null elsewhere. */
 function steamPathFromRegistryP() {
-  if (process.platform !== 'win32') return Promise.resolve(null);
-  return new Promise((resolvePromise) => {
-    try {
-      const reg = join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'reg.exe');
-      // 异步 execFile（保留 5s timeout）：同步 execFileSync 会阻塞事件循环数秒
-      // （reg.exe 冷启动慢），而调用链本就全 async，无需在此阻塞。
-      execFile(
-        reg,
-        ['query', 'HKCU\\Software\\Valve\\Steam', '/v', 'SteamPath'],
-        { encoding: 'utf8', windowsHide: true, timeout: 5000 },
-        (err, stdout) => {
-          if (err) { resolvePromise(null); return; }
-          const m = /SteamPath\s+REG_SZ\s+(.+)/i.exec(stdout || '');
-          resolvePromise(m ? normalize(m[1].trim()) : null);
-        },
-      );
-    } catch { resolvePromise(null); }
+  return resolveRegExeP().then((reg) => {
+    if (!reg) return null;
+    return new Promise((resolvePromise) => {
+      try {
+        // async execFile (5s timeout): execFileSync would block the event loop.
+        execFile(
+          reg,
+          ['query', 'HKCU\\Software\\Valve\\Steam', '/v', 'SteamPath'],
+          { encoding: 'utf8', windowsHide: true, timeout: 5000 },
+          (err, stdout) => {
+            if (err) { resolvePromise(null); return; }
+            const m = /SteamPath\s+REG_SZ\s+(.+)/i.exec(stdout || '');
+            const p = m ? normalize(m[1].trim()) : null;
+            resolvePromise(p ? wslPath(p) : null);
+          },
+        );
+      } catch { resolvePromise(null); }
+    });
   });
+}
+
+/** Steam roots from DSH_WE_STEAM_ROOT (comma/semicolon separated, Windows or /mnt paths). */
+function steamRootsFromEnv() {
+  const raw = process.env.DSH_WE_STEAM_ROOT && process.env.DSH_WE_STEAM_ROOT.trim();
+  if (!raw) return [];
+  return raw
+    .split(/[,;]/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(wslPath);
 }
 
 /** Async existence probes (fs.promises — thread pool, no event-loop blocking). */
@@ -144,7 +171,7 @@ const STEAM_PROBE_TTL_MS = 60 * 1000;
 let steamProbeCache = null; // { t, dirs }
 let steamProbeInflight = null;
 
-/** Probe list: registry root first, then known dirs, then WSL /mnt mounts. */
+/** Probe list: registry root + env override(s), then known dirs, then WSL /mnt mounts. */
 async function steamProbeDirsP() {
   if (steamProbeCache && Date.now() - steamProbeCache.t < STEAM_PROBE_TTL_MS) {
     return steamProbeCache.dirs;
@@ -152,8 +179,9 @@ async function steamProbeDirsP() {
   if (steamProbeInflight) return steamProbeInflight;
   steamProbeInflight = (async () => {
     const reg = await steamPathFromRegistryP();
+    const env = steamRootsFromEnv();
     const wsl = await wslSteamRootsP();
-    return [...(reg ? [reg] : []), ...STEAM_PROBE_DIRS, ...wsl];
+    return [...(reg ? [reg] : []), ...env, ...STEAM_PROBE_DIRS, ...wsl];
   })();
   try {
     const dirs = await steamProbeInflight;


### PR DESCRIPTION
## Summary

Fixes Wallpaper Engine not being detected when the Harness runs inside WSL2 and Steam is installed in a custom directory (e.g. `D:\Game\Steam`). The host half now reads `HKCU\Software\Valve\Steam\SteamPath` through the Windows `reg.exe` copy under `/mnt/<letter>/Windows/System32`, so custom Steam roots are auto-discovered on WSL exactly as they already are on native Windows. An explicit `DSH_WE_STEAM_ROOT` env override is added as a fallback.

Closes #40 · supersedes the withdrawn #41 · rebased on latest upstream `main` (`2f0043f`, 0.6.x) · single commit `96de09e` · **3 files, +50/−20**

## Problem

Two gaps in `lib/index.js`:

1. `wslSteamRootsP()` only probes the four *standard* Steam locations per mounted drive (`Program Files (x86)/Steam`, `Program Files/Steam`, `Steam`, `SteamLibrary`) — a custom root like `D:\Game\Steam` is never hit.
2. `steamPathFromRegistryP()` is win32-only (`process.platform !== 'win32'` → null), so WSL never uses the registry even though `reg.exe` works fine from WSL with no extra privileges.

## Changes

Adapted to the current upstream structure (async `execFile`, 60s probe cache, `…P` naming):

- **`resolveRegExeP()`** (new): SystemRoot `reg.exe` on Windows; on WSL, probes `/mnt/<letter>/Windows/System32/reg.exe` (async, thread-pool — follows the existing DrvFS non-blocking convention). Returns `null` on every other platform.
- **`steamPathFromRegistryP()`** (extended): upstream's win32-only Promise/`execFile` version now also resolves under WSL, and the result is translated via the existing `wslPath()` to its `/mnt` form, so the `libraryfolders.vdf` chain resolves the owning library on any drive (verified: D: registry root → E: install found).
- **`steamRootsFromEnv()` + `steamProbeDirsP()`**: `DSH_WE_STEAM_ROOT` env override (comma/semicolon separated, Windows or `/mnt` paths) injected into the cached probe list.
- **`README.md` / `README.en.md`**: one env-var table row each for `DSH_WE_STEAM_ROOT`.

## Verification (WSL2, real environment)

| Check | Result |
|---|---|
| `resolveRegExeP()` | `/mnt/c/Windows/System32/reg.exe` (registry query `exit=0`, no privileges needed) |
| `steamPathFromRegistryP()` | `/mnt/d/game/steam` |
| `locateWallpaperEngineP()` | `/mnt/e/Game/Steam/steamapps/common/wallpaper_engine` |
| `owningLibrariesP()` | `['/mnt/e/Game/Steam']` |
| Inventory enumeration | **97 wallpapers** (32 video / 60 scene / 5 web) |
| `DSH_WE_STEAM_ROOT` | single / multi-value / Windows-style forms all resolve |
| `npm run verify` | all checks pass |
| `node --check lib/index.js` | pass |

## Compatibility

- **Non-WSL Linux/macOS are unaffected**: the `reg.exe` probe only looks under `/mnt/<drive-letter>/Windows/System32`, which those platforms do not have, so the lookup returns `null` exactly as before.
- **Native Windows path is unchanged** (SystemRoot); the result now passes through the no-op `wslPath()` there.