### PR TITLE
mac: vinyl 缩略图兜底 + 启动/更新时保持已选壁纸

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -920,11 +920,19 @@ window.__ModuleLoader__.load({
 		// the "CD player" presentation the author liked. Pure presentational: cover =
 		// the current wallpaper's preview URL (or null), playing drives the spin.
 		// Shown in BOTH settings layouts and in the picker modal head.
+		//
+		// Fallback chain for mac loose media (no sidecar preview):
+		//   1. img with preview URL (WE projects with preview files)
+		//   2. video with preload=metadata (mac loose videos → first frame)
+		//   3. ▦ placeholder (nothing available)
 		function VinylRecord(props) {
 		  const cover = props.cover;
+		  const type = props.type;
+		  const url = props.url;
 		  const title = props.title || "未选择壁纸";
 		  const playing = props.playing === true;
 		  const sm = props.sm === true;
+		  const hasVideoFallback = type === "video" && url;
 		  return React.createElement("div", {
 		    className: "we-vinyl" +
 		      (playing ? " we-vinyl--playing" : "") +
@@ -935,9 +943,21 @@ window.__ModuleLoader__.load({
 		      cover
 		        ? React.createElement("img", {
 		            src: cover, alt: "", loading: "lazy",
-		            onError: (e) => { e.target.style.display = "none"; },
+		            onError: (e) => {
+		              // Preview failed → fall back to video first frame if available
+		              if (hasVideoFallback) {
+		                e.target.replaceWith(Object.assign(document.createElement("video"), {
+		                  src: url, preload: "metadata", muted: true,
+		                  style: "width:100%;height:100%;object-fit:cover;display:block",
+		                }));
+		              } else {
+		                e.target.style.display = "none";
+		              }
+		            },
 		          })
-		        : React.createElement("span", { className: "we-vinyl__empty" }, "▦"),
+		        : (hasVideoFallback
+		            ? React.createElement("video", { src: url, preload: "metadata", muted: true, playsInline: true })
+		            : React.createElement("span", { className: "we-vinyl__empty" }, "▦")),
 		    ),
 		    React.createElement("span", { className: "we-vinyl__hole" }),
 		  );
@@ -1240,7 +1260,8 @@ window.__ModuleLoader__.load({
 		    React.createElement("div", { className: "we-picker__section" },
 		      React.createElement("div", { className: "we-picker__current" },
 		        React.createElement(VinylRecord, {
-		          cover: current && current.preview, title: current ? current.title : "",
+		          cover: current && current.preview, type: current && current.type, url: current && current.url,
+		          title: current ? current.title : "",
 		          playing: sel.playing && Boolean(sel.url),
 		        }),
 		        React.createElement("div", { className: "we-picker__current-info" },
@@ -1270,7 +1291,8 @@ window.__ModuleLoader__.load({
 		          React.createElement("div", { className: "we-picker__modal-head" },
 		            React.createElement("div", { className: "we-picker__modal-head-left" },
 		              React.createElement(VinylRecord, {
-		                cover: current && current.preview, title: current ? current.title : "",
+		                cover: current && current.preview, type: current && current.type, url: current && current.url,
+		                title: current ? current.title : "",
 		                playing: sel.playing && Boolean(sel.url), sm: true,
 		              }),
 		              React.createElement("span", { className: "we-picker__modal-title" }, "选择壁纸"),
@@ -2149,7 +2171,7 @@ window.__ModuleLoader__.load({
 		      0 0 0 2px rgba(255, 255, 255, 0.1),
 		      inset 0 0 8px rgba(0, 0, 0, 0.6);
 		  }
-		  .we-vinyl__cover img { width: 100%; height: 100%; object-fit: cover; display: block; }
+		  .we-vinyl__cover img, .we-vinyl__cover video { width: 100%; height: 100%; object-fit: cover; display: block; }
 		  .we-vinyl__empty {
 		    position: absolute; inset: 0;
 		    display: flex; align-items: center; justify-content: center;

--- a/lib/client.js
+++ b/lib/client.js
@@ -893,9 +893,9 @@ window.__ModuleLoader__.load({
 		const cardThumb = (w) => w.preview
 		  ? React.createElement("img", { src: w.preview, alt: w.title, loading: "lazy", onError: (e) => { e.target.style.display = "none"; } })
 		  : (w.type === "image"
-		      ? React.createElement("img", { src: w.media, alt: w.title, loading: "lazy" })
+		      ? React.createElement("img", { src: w.media, alt: w.title, loading: "lazy", onError: (e) => { e.target.style.display = "none"; } })
 		      : (w.type === "video"
-		          ? React.createElement("video", { src: w.media, preload: "metadata", muted: true, playsInline: true })
+		          ? React.createElement("video", { src: w.media, preload: "metadata", muted: true, playsInline: true, onError: (e) => { e.target.style.display = "none"; } })
 		          : React.createElement("span", { className: "we-picker__card-placeholder" }, "无预览")));
 
 		function SliderRow(label, min, max, step, value, onInput, suffix) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -373,6 +373,10 @@ window.__ModuleLoader__.load({
 		// selected categories; when rotation is on and nothing matches, pick the next
 		// candidate instead of stopping playback.
 		function revalidateSelection() {
+		  // Empty inventory = the scan hasn't finished / the host isn't ready yet
+		  // (boot, bundle update, WSL mount lag). Keep the saved selection instead of
+		  // wiping it — re-validation runs again on the next successful refresh.
+		  if (selection.inventory.wallpapers.length === 0) return;
 		  if (selection.id && !selection.inventory.wallpapers.some((w) => w.id === selection.id && isRotatableWallpaper(w))) {
 		    selection.id = "";
 		    persistSelection();

--- a/lib/client.js
+++ b/lib/client.js
@@ -923,7 +923,7 @@ window.__ModuleLoader__.load({
 		//
 		// Fallback chain for mac loose media (no sidecar preview):
 		//   1. img with preview URL (WE projects with preview files)
-		//   2. video with preload=metadata (mac loose videos → first frame)
+		//   2. original media (mac loose images render directly; videos show first frame)
 		//   3. ▦ placeholder (nothing available)
 		function VinylRecord(props) {
 		  const cover = props.cover;
@@ -932,7 +932,12 @@ window.__ModuleLoader__.load({
 		  const title = props.title || "未选择壁纸";
 		  const playing = props.playing === true;
 		  const sm = props.sm === true;
-		  const hasVideoFallback = type === "video" && url;
+		  const hasMediaFallback = (type === "video" || type === "image") && url;
+		  const mediaFallback = type === "video" && hasMediaFallback
+		    ? React.createElement("video", { src: url, preload: "metadata", muted: true, playsInline: true })
+		    : (type === "image" && hasMediaFallback
+		        ? React.createElement("img", { src: url, alt: "", loading: "lazy" })
+		        : React.createElement("span", { className: "we-vinyl__empty" }, "▦"));
 		  return React.createElement("div", {
 		    className: "we-vinyl" +
 		      (playing ? " we-vinyl--playing" : "") +
@@ -944,20 +949,21 @@ window.__ModuleLoader__.load({
 		        ? React.createElement("img", {
 		            src: cover, alt: "", loading: "lazy",
 		            onError: (e) => {
-		              // Preview failed → fall back to video first frame if available
-		              if (hasVideoFallback) {
-		                e.target.replaceWith(Object.assign(document.createElement("video"), {
-		                  src: url, preload: "metadata", muted: true,
-		                  style: "width:100%;height:100%;object-fit:cover;display:block",
-		                }));
+		              // Preview failed → fall back to the original media if available
+		              if (hasMediaFallback) {
+		                const tag = type === "video" ? "video" : "img";
+		                e.target.replaceWith(Object.assign(document.createElement(tag), type === "video"
+		                  ? {
+		                      src: url, preload: "metadata", muted: true, playsInline: true,
+		                      style: "width:100%;height:100%;object-fit:cover;display:block",
+		                    }
+		                  : { src: url, alt: "", loading: "lazy", style: "width:100%;height:100%;object-fit:cover;display:block" }));
 		              } else {
 		                e.target.style.display = "none";
 		              }
 		            },
 		          })
-		        : (hasVideoFallback
-		            ? React.createElement("video", { src: url, preload: "metadata", muted: true, playsInline: true })
-		            : React.createElement("span", { className: "we-vinyl__empty" }, "▦")),
+		        : mediaFallback
 		    ),
 		    React.createElement("span", { className: "we-vinyl__hole" }),
 		  );
@@ -1260,7 +1266,7 @@ window.__ModuleLoader__.load({
 		    React.createElement("div", { className: "we-picker__section" },
 		      React.createElement("div", { className: "we-picker__current" },
 		        React.createElement(VinylRecord, {
-		          cover: current && current.preview, type: current && current.type, url: current && current.url,
+		          cover: current && current.preview, type: current && current.type, url: current && current.media,
 		          title: current ? current.title : "",
 		          playing: sel.playing && Boolean(sel.url),
 		        }),
@@ -1291,7 +1297,7 @@ window.__ModuleLoader__.load({
 		          React.createElement("div", { className: "we-picker__modal-head" },
 		            React.createElement("div", { className: "we-picker__modal-head-left" },
 		              React.createElement(VinylRecord, {
-		                cover: current && current.preview, type: current && current.type, url: current && current.url,
+		                cover: current && current.preview, type: current && current.type, url: current && current.media,
 		                title: current ? current.title : "",
 		                playing: sel.playing && Boolean(sel.url), sm: true,
 		              }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-wallpaper-engine",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Wallpaper Engine backgrounds for the DSH web GUI: render your local Wallpaper Engine Video/Web wallpapers behind the chat, Scene wallpapers as extracted static frames, with iOS-style liquid glass, adjustable scrim/border/blur, and a customizable accent color + glass transparency for the whole settings window.",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-wallpaper-engine",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Wallpaper Engine backgrounds for the DSH web GUI: render your local Wallpaper Engine Video/Web wallpapers behind the chat, Scene wallpapers as extracted static frames, with iOS-style liquid glass, adjustable scrim/border/blur, and a customizable accent color + glass transparency for the whole settings window.",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-wallpaper-engine",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Wallpaper Engine backgrounds for the DSH web GUI: render your local Wallpaper Engine Video/Web wallpapers behind the chat, Scene wallpapers as extracted static frames, with iOS-style liquid glass, adjustable scrim/border/blur, and a customizable accent color + glass transparency for the whole settings window.",
   "type": "module",
   "engines": {

--- a/scripts/verify-client.mjs
+++ b/scripts/verify-client.mjs
@@ -67,7 +67,9 @@ const fetch = () => Promise.resolve({
       { id: "p1", name: "Test playlist", order: "sequence", wallpaperIds: ["a", "b", "c"], total: 3, portableCount: 2 },
     ],
     wallpapers: [
-      // 30 synthetic videos force pagination (33 playable cards → 2 pages at 24/page).
+      { id: "img", title: "Image C", type: "image", playable: true, media: "/wallpaper-engine/media/image", preview: null, contentrating: "Everyone" },
+      // 30 synthetic videos plus one image force pagination (34 visible cards
+      // → 2 pages at 24/page).
       // All carry contentrating "Everyone" so they stay visible under the
       // default Everyone filter.
       ...Array.from({ length: 30 }, (_, i) => ({
@@ -201,6 +203,24 @@ setTimeout(() => {
       console.log('玻璃 slider max (expect 60):', sliderMax);
       console.log('whole-window glass master switch present:', treeText.includes('设置窗口液态玻璃'));
       console.log('window glass hint present:', treeText.includes('整个设置窗口'));
+
+      // Regression: a selected mac loose video has no sidecar preview. The
+      // current vinyl must therefore render the wallpaper's media URL as a
+      // video fallback, not an empty placeholder.
+      const vinyls = [];
+      (function walkVinyl(node) {
+        if (Array.isArray(node)) { node.forEach(walkVinyl); return; }
+        if (!node || typeof node !== 'object') return;
+        const cls = typeof node.props?.className === 'string' ? node.props.className : '';
+        if (cls.includes('we-vinyl')) vinyls.push(node);
+        if (Array.isArray(node.children)) node.children.forEach(walkVinyl);
+      })(tree);
+      const currentVinylVideo = vinyls[0] && vinyls[0].children?.[0]?.children?.find((node) => node && node.type === 'video');
+      console.log('selected previewless video has vinyl video fallback:', !!currentVinylVideo);
+      if (!currentVinylVideo || currentVinylVideo.props?.src !== '/wallpaper-engine/media/xyz') {
+        throw new Error('vinyl video fallback regression: expected selected wallpaper media URL');
+      }
+
       // The thumbnail grid lives inside the picker MODAL now (settings page
       // shows only the summary + "选择壁纸" trigger). Open the modal by
       // invoking the trigger button's onClick, re-render, then count cards.
@@ -216,6 +236,30 @@ setTimeout(() => {
         try { openBtn[0].props.onClick(); } catch (e) { console.log('open modal onClick threw:', e && e.message); }
       }
       try { tree = pickerRenders[0](); } catch (e) { renderError = e && e.message; }
+      const imageCard = [];
+      (function findImageCard(node) {
+        if (Array.isArray(node)) { node.forEach(findImageCard); return; }
+        if (!node || typeof node !== 'object') return;
+        const cls = typeof node.props?.className === 'string' ? node.props.className : '';
+        if ((cls === 'we-picker__card' || cls === 'we-picker__card we-picker__card--selected') && Array.isArray(node.children) && node.children.some((child) => child && Array.isArray(child.children) && child.children.includes('Image C'))) imageCard.push(node);
+        if (Array.isArray(node.children)) node.children.forEach(findImageCard);
+      })(tree);
+      if (imageCard[0] && typeof imageCard[0].props?.onClick === 'function') imageCard[0].props.onClick();
+      try { tree = pickerRenders[0](); } catch (e) { renderError = e && e.message; }
+      const imageVinyls = [];
+      (function walkImageVinyl(node) {
+        if (Array.isArray(node)) { node.forEach(walkImageVinyl); return; }
+        if (!node || typeof node !== 'object') return;
+        const cls = typeof node.props?.className === 'string' ? node.props.className : '';
+        if (cls.includes('we-vinyl')) imageVinyls.push(node);
+        if (Array.isArray(node.children)) node.children.forEach(walkImageVinyl);
+      })(tree);
+      const currentVinylImage = imageVinyls[0] && imageVinyls[0].children?.[0]?.children?.find((node) => node && node.type === 'img');
+      console.log('selected previewless image has vinyl image fallback:', !!currentVinylImage);
+      if (!currentVinylImage || currentVinylImage.props?.src !== '/wallpaper-engine/media/image') {
+        throw new Error('vinyl image fallback regression: expected selected wallpaper media URL');
+      }
+
       const collectCards = (root) => {
         const cards = [];
         (function walk2(node) {
@@ -252,7 +296,7 @@ setTimeout(() => {
       clickPager(tree, '下一页 ›');
       try { tree = pickerRenders[0](); } catch (e) { renderError = e && e.message; }
       cards = collectCards(tree);
-      console.log('page 2 cards (expect 10: close + 9):', cards.length);
+      console.log('page 2 cards (expect 11: close + 10):', cards.length);
       const page2Text = JSON.stringify(cards);
       console.log('page 2 shows last wallpaper (Wall 29):', page2Text.includes('Wall 29'));
       console.log('page 2 no longer shows page-1 item (Wall 0):', !page2Text.includes('Wall 0'));

--- a/src/client.js
+++ b/src/client.js
@@ -944,11 +944,19 @@ function SliderRow(label, min, max, step, value, onInput, suffix) {
 // the "CD player" presentation the author liked. Pure presentational: cover =
 // the current wallpaper's preview URL (or null), playing drives the spin.
 // Shown in BOTH settings layouts and in the picker modal head.
+//
+// Fallback chain for mac loose media (no sidecar preview):
+//   1. img with preview URL (WE projects with preview files)
+//   2. video with preload=metadata (mac loose videos → first frame)
+//   3. ▦ placeholder (nothing available)
 function VinylRecord(props) {
   const cover = props.cover;
+  const type = props.type;
+  const url = props.url;
   const title = props.title || "未选择壁纸";
   const playing = props.playing === true;
   const sm = props.sm === true;
+  const hasVideoFallback = type === "video" && url;
   return React.createElement("div", {
     className: "we-vinyl" +
       (playing ? " we-vinyl--playing" : "") +
@@ -959,9 +967,21 @@ function VinylRecord(props) {
       cover
         ? React.createElement("img", {
             src: cover, alt: "", loading: "lazy",
-            onError: (e) => { e.target.style.display = "none"; },
+            onError: (e) => {
+              // Preview failed → fall back to video first frame if available
+              if (hasVideoFallback) {
+                e.target.replaceWith(Object.assign(document.createElement("video"), {
+                  src: url, preload: "metadata", muted: true,
+                  style: "width:100%;height:100%;object-fit:cover;display:block",
+                }));
+              } else {
+                e.target.style.display = "none";
+              }
+            },
           })
-        : React.createElement("span", { className: "we-vinyl__empty" }, "▦"),
+        : (hasVideoFallback
+            ? React.createElement("video", { src: url, preload: "metadata", muted: true, playsInline: true })
+            : React.createElement("span", { className: "we-vinyl__empty" }, "▦")),
     ),
     React.createElement("span", { className: "we-vinyl__hole" }),
   );
@@ -1264,7 +1284,8 @@ function WallpaperPicker() {
     React.createElement("div", { className: "we-picker__section" },
       React.createElement("div", { className: "we-picker__current" },
         React.createElement(VinylRecord, {
-          cover: current && current.preview, title: current ? current.title : "",
+          cover: current && current.preview, type: current && current.type, url: current && current.url,
+          title: current ? current.title : "",
           playing: sel.playing && Boolean(sel.url),
         }),
         React.createElement("div", { className: "we-picker__current-info" },
@@ -1294,7 +1315,8 @@ function WallpaperPicker() {
           React.createElement("div", { className: "we-picker__modal-head" },
             React.createElement("div", { className: "we-picker__modal-head-left" },
               React.createElement(VinylRecord, {
-                cover: current && current.preview, title: current ? current.title : "",
+                cover: current && current.preview, type: current && current.type, url: current && current.url,
+                title: current ? current.title : "",
                 playing: sel.playing && Boolean(sel.url), sm: true,
               }),
               React.createElement("span", { className: "we-picker__modal-title" }, "选择壁纸"),
@@ -2173,7 +2195,7 @@ const CSS = `
       0 0 0 2px rgba(255, 255, 255, 0.1),
       inset 0 0 8px rgba(0, 0, 0, 0.6);
   }
-  .we-vinyl__cover img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .we-vinyl__cover img, .we-vinyl__cover video { width: 100%; height: 100%; object-fit: cover; display: block; }
   .we-vinyl__empty {
     position: absolute; inset: 0;
     display: flex; align-items: center; justify-content: center;

--- a/src/client.js
+++ b/src/client.js
@@ -947,7 +947,7 @@ function SliderRow(label, min, max, step, value, onInput, suffix) {
 //
 // Fallback chain for mac loose media (no sidecar preview):
 //   1. img with preview URL (WE projects with preview files)
-//   2. video with preload=metadata (mac loose videos → first frame)
+//   2. original media (mac loose images render directly; videos show first frame)
 //   3. ▦ placeholder (nothing available)
 function VinylRecord(props) {
   const cover = props.cover;
@@ -956,7 +956,12 @@ function VinylRecord(props) {
   const title = props.title || "未选择壁纸";
   const playing = props.playing === true;
   const sm = props.sm === true;
-  const hasVideoFallback = type === "video" && url;
+  const hasMediaFallback = (type === "video" || type === "image") && url;
+  const mediaFallback = type === "video" && hasMediaFallback
+    ? React.createElement("video", { src: url, preload: "metadata", muted: true, playsInline: true })
+    : (type === "image" && hasMediaFallback
+        ? React.createElement("img", { src: url, alt: "", loading: "lazy" })
+        : React.createElement("span", { className: "we-vinyl__empty" }, "▦"));
   return React.createElement("div", {
     className: "we-vinyl" +
       (playing ? " we-vinyl--playing" : "") +
@@ -968,20 +973,21 @@ function VinylRecord(props) {
         ? React.createElement("img", {
             src: cover, alt: "", loading: "lazy",
             onError: (e) => {
-              // Preview failed → fall back to video first frame if available
-              if (hasVideoFallback) {
-                e.target.replaceWith(Object.assign(document.createElement("video"), {
-                  src: url, preload: "metadata", muted: true,
-                  style: "width:100%;height:100%;object-fit:cover;display:block",
-                }));
+              // Preview failed → fall back to the original media if available
+              if (hasMediaFallback) {
+                const tag = type === "video" ? "video" : "img";
+                e.target.replaceWith(Object.assign(document.createElement(tag), type === "video"
+                  ? {
+                      src: url, preload: "metadata", muted: true, playsInline: true,
+                      style: "width:100%;height:100%;object-fit:cover;display:block",
+                    }
+                  : { src: url, alt: "", loading: "lazy", style: "width:100%;height:100%;object-fit:cover;display:block" }));
               } else {
                 e.target.style.display = "none";
               }
             },
           })
-        : (hasVideoFallback
-            ? React.createElement("video", { src: url, preload: "metadata", muted: true, playsInline: true })
-            : React.createElement("span", { className: "we-vinyl__empty" }, "▦")),
+        : mediaFallback
     ),
     React.createElement("span", { className: "we-vinyl__hole" }),
   );
@@ -1284,7 +1290,7 @@ function WallpaperPicker() {
     React.createElement("div", { className: "we-picker__section" },
       React.createElement("div", { className: "we-picker__current" },
         React.createElement(VinylRecord, {
-          cover: current && current.preview, type: current && current.type, url: current && current.url,
+          cover: current && current.preview, type: current && current.type, url: current && current.media,
           title: current ? current.title : "",
           playing: sel.playing && Boolean(sel.url),
         }),
@@ -1315,7 +1321,7 @@ function WallpaperPicker() {
           React.createElement("div", { className: "we-picker__modal-head" },
             React.createElement("div", { className: "we-picker__modal-head-left" },
               React.createElement(VinylRecord, {
-                cover: current && current.preview, type: current && current.type, url: current && current.url,
+                cover: current && current.preview, type: current && current.type, url: current && current.media,
                 title: current ? current.title : "",
                 playing: sel.playing && Boolean(sel.url), sm: true,
               }),

--- a/src/client.js
+++ b/src/client.js
@@ -397,6 +397,10 @@ function playableInventory() {
 // selected categories; when rotation is on and nothing matches, pick the next
 // candidate instead of stopping playback.
 function revalidateSelection() {
+  // Empty inventory = the scan hasn't finished / the host isn't ready yet
+  // (boot, bundle update, WSL mount lag). Keep the saved selection instead of
+  // wiping it — re-validation runs again on the next successful refresh.
+  if (selection.inventory.wallpapers.length === 0) return;
   if (selection.id && !selection.inventory.wallpapers.some((w) => w.id === selection.id && isRotatableWallpaper(w))) {
     selection.id = "";
     persistSelection();

--- a/src/client.js
+++ b/src/client.js
@@ -917,9 +917,9 @@ function clearEffects() {
 const cardThumb = (w) => w.preview
   ? React.createElement("img", { src: w.preview, alt: w.title, loading: "lazy", onError: (e) => { e.target.style.display = "none"; } })
   : (w.type === "image"
-      ? React.createElement("img", { src: w.media, alt: w.title, loading: "lazy" })
+      ? React.createElement("img", { src: w.media, alt: w.title, loading: "lazy", onError: (e) => { e.target.style.display = "none"; } })
       : (w.type === "video"
-          ? React.createElement("video", { src: w.media, preload: "metadata", muted: true, playsInline: true })
+          ? React.createElement("video", { src: w.media, preload: "metadata", muted: true, playsInline: true, onError: (e) => { e.target.style.display = "none"; } })
           : React.createElement("span", { className: "we-picker__card-placeholder" }, "无预览")));
 
 function SliderRow(label, min, max, step, value, onInput, suffix) {


### PR DESCRIPTION
来自 ruijiaang-lab/mac 的 4 个 mac 端修复：

1. fix: keep saved wallpaper selection when inventory is empty（启动/更新竞态）
2. fix: hide video thumbnails that fail to load（不支持的编码 / 大 4K 首帧黑卡守卫）
3. fix: vinyl record shows video first frame when preview is unavailable（mac 松散媒体）
4. fix: show media fallback in vinyl record

无冲突，可直接合并到 mac 分支。