### PR TITLE
fix(mac): 扫描 WaifuX 嵌套 workshop 目录

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -269,14 +269,21 @@ function enumerateWallpapers(installDir, libraryDirs, extraRoots = []) {
       let st; try { st = statSync(dir); } catch { continue; }
       if (st.isDirectory()) {
         const proj = readProject(dir);
-        if (!proj || found.has(proj.id)) continue;
-        // Scenes: resolve the real container (scene.pkg vs scene.json) so the
-        // scene-frame route reads a file that actually exists.
-        proj.fileAbs = proj.type === 'scene'
-          ? (() => { const main = resolveSceneMainFile(dir, proj.file); return resolve(dir, main || proj.file); })()
-          : resolve(dir, proj.file);
-        proj.previewAbs = proj.preview ? resolve(dir, proj.preview) : null;
-        found.set(proj.id, proj);
+        if (proj && !found.has(proj.id)) {
+          // Scenes: resolve the real container (scene.pkg vs scene.json) so the
+          // scene-frame route reads a file that actually exists.
+          proj.fileAbs = proj.type === 'scene'
+            ? (() => { const main = resolveSceneMainFile(dir, proj.file); return resolve(dir, main || proj.file); })()
+            : resolve(dir, proj.file);
+          proj.previewAbs = proj.preview ? resolve(dir, proj.preview) : null;
+          found.set(proj.id, proj);
+          continue;
+        }
+        // WaifuX nests each workshop item under a container dir with no
+        // project.json here: Media/workshop_<id>/steamapps/workshop/content/
+        // 431960/<id>/project.json. Push the nested layer back onto the scan.
+        const nested = join(dir, 'steamapps', 'workshop', 'content', WE_APPID);
+        if (existsSync(nested)) roots.push(nested);
         continue;
       }
       // Loose media file (macOS adaptation): a bare .mp4/.png/… in the content


### PR DESCRIPTION
WaifuX 会把每个 workshop 项目套一层容器目录：\n`Media/workshop_<id>/steamapps/workshop/content/431960/<id>/project.json`\n\n原来的扫描只找一层就停，导致这些嵌套项目扫不到。本修复把嵌套层重新压回扫描队列。\n\n只改动 lib/index.js，无冲突。