### PR TITLE
feat(rope): add persisted toggle to show the chat mascot pull-cord

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -119,6 +119,8 @@ window.__ModuleLoader__.load({
 		  sidebarBlur: 16,
 		  sidebarAlpha: 12,
 		  sidebarColor: "#ffffff",
+		  // Persisted: show the chat-interface mascot pull-cord (rope dock).
+		  ropeShown: true,
 		};
 
 		// Selectable values for the two filters. Declared up top because
@@ -224,6 +226,7 @@ window.__ModuleLoader__.load({
 		    sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, DEFAULTS.sidebarAlpha),
 		    sidebarColor: typeof o.sidebarColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
 		      ? o.sidebarColor : DEFAULTS.sidebarColor,
+		    ropeShown: o.ropeShown !== false,
 		  };
 		}
 
@@ -336,6 +339,7 @@ window.__ModuleLoader__.load({
 		    sidebarBlur: selection.sidebarBlur,
 		    sidebarAlpha: selection.sidebarAlpha,
 		    sidebarColor: selection.sidebarColor,
+		    ropeShown: selection.ropeShown,
 		  };
 		}
 
@@ -1847,6 +1851,11 @@ window.__ModuleLoader__.load({
 		    selection.sidebarColor = hex;
 		    persistSelection(); emit();
 		  };
+		  // Mascot pull-cord show/hide, persisted with the other toggles.
+		  const onRopeVisibilityChange = (e) => {
+		    selection.ropeShown = e.target.checked;
+		    persistSelection(); emit();
+		  };
 
 		  // Close the picker modal (ESC / backdrop / close buttons share this path).
 		  const closePicker = () => {
@@ -2092,6 +2101,18 @@ window.__ModuleLoader__.load({
 		        ),
 		      ),
 		      ],
+		      // Chat-interface mascot (rope dock): show/hide the pull-cord + repo drawer.
+		      React.createElement("label", { className: "we-picker__rotation-toggle we-picker__window-toggle" },
+		        React.createElement("input", {
+		          type: "checkbox",
+		          checked: sel.ropeShown !== false,
+		          onChange: onRopeVisibilityChange,
+		        }),
+		        "显示吉祥物（聊天顶部拉绳）",
+		      ),
+		      React.createElement("span", { className: "we-picker__hint" },
+		        "关闭后隐藏吉祥物与壁纸仓库抽屉；可随时在本页重新开启",
+		      ),
 		    ),
 		    // ── Card-style switch: classic (WE's original aspect-ratio 16/9 cards —
 		    //    the CD-like look the author liked) vs the rewritten fixed-height
@@ -2890,6 +2911,8 @@ window.__ModuleLoader__.load({
 		}
 
 		function RopeDock() {
+		  const sel = useStore();
+		  const hidden = !sel.ropeShown;
 		  const [open, setOpen] = React.useState(false);
 		  const [pos, setPos] = React.useState(readRopePos);
 		  const ropeRef = React.useRef(null);
@@ -3025,15 +3048,25 @@ window.__ModuleLoader__.load({
 		    return () => window.removeEventListener("resize", onResize);
 		  }, []);
 
-		  // Claim modal ownership ONLY while the panel is open (its picker is mounted).
-		  // When closed the picker is unmounted, so the settings copy must own the modal
-		  // again — otherwise 选择壁纸 from settings would open nothing. Flipping the
-		  // flag triggers emit() so the settings copy re-renders immediately.
+		  // Claim modal ownership ONLY while the panel is open AND the rope is visible
+		  // (its picker is mounted). When closed or hidden the picker is unmounted, so
+		  // the settings copy must own the modal again — otherwise 选择壁纸 from settings
+		  // would open nothing. emit() keeps the settings copy in sync; hiding while
+		  // open also closes the drawer, so ownership never sticks to an invisible panel.
 		  React.useEffect(() => {
-		    repoPanelOwnsModal = open;
+		    if (hidden) setOpen(false);
+		    repoPanelOwnsModal = open && !hidden;
 		    emit();
 		    return () => { repoPanelOwnsModal = false; emit(); };
-		  }, [open]);
+		  }, [open, hidden]);
+
+		  // Hidden: render nothing (rope + drawer), but keep the one-time update
+		  // notice — it is independent of the mascot and must still surface.
+		  if (hidden) {
+		    return React.createElement(React.Fragment, null,
+		      React.createElement(UpdateNotice, null),
+		    );
+		  }
 
 		  return React.createElement(React.Fragment, null,
 		    React.createElement("div", {

--- a/lib/index.js
+++ b/lib/index.js
@@ -628,6 +628,8 @@ function sanitizeSettings(raw) {
     sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, 12),
     sidebarColor: typeof o.sidebarColor === 'string' && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
       ? o.sidebarColor : '#ffffff',
+    // Chat-interface mascot pull-cord visibility (mirror of src/client.js).
+    ropeShown: o.ropeShown !== false,
   };
 }
 

--- a/scripts/verify-client.mjs
+++ b/scripts/verify-client.mjs
@@ -227,6 +227,38 @@ setTimeout(() => {
       } else {
         console.log('switch off hides the three detail knobs: false (switch not found)');
       }
+      // Mascot rope-dock visibility toggle: present by default (checked),
+      // unchecking flips the persisted flag (checkbox off), re-checking
+      // restores it — re-renders read the live `selection`.
+      const findRopeToggle = (root) => {
+        let hit = null;
+        (function walk(node) {
+          if (Array.isArray(node)) { node.forEach(walk); return; }
+          if (!node || typeof node !== 'object') return;
+          const children = Array.isArray(node.children) ? node.children : [];
+          if (children.includes('显示吉祥物（聊天顶部拉绳）')) {
+            const input = children.find((c) => c && typeof c === 'object' && c.type === 'input');
+            if (input && typeof input.props.onChange === 'function') hit = input;
+          }
+          if (Array.isArray(node.children)) node.children.forEach(walk);
+        })(root);
+        return hit;
+      };
+      const ropeToggle = findRopeToggle(tree);
+      console.log('mascot rope toggle present:', !!ropeToggle);
+      if (ropeToggle) {
+        console.log('rope toggle checked by default:', ropeToggle.props.checked === true);
+        ropeToggle.props.onChange({ target: { checked: false } });
+        tree = pickerRenders[0]();
+        const ropeOff = findRopeToggle(tree);
+        console.log('unchecking hides the rope (checkbox off):', !!ropeOff && ropeOff.props.checked === false);
+        ropeToggle.props.onChange({ target: { checked: true } });
+        tree = pickerRenders[0]();
+        const ropeOn = findRopeToggle(tree);
+        console.log('re-checking restores the rope (checkbox on):', !!ropeOn && ropeOn.props.checked === true);
+      } else {
+        console.log('mascot rope toggle: false (not found)');
+      }
       // 玻璃 slider now spans 0–60 px (was 0–40): assert the raised max on the
       // 玻璃 range input (label "玻璃", max 60) so the range stays in sync.
       const glassSlider = (() => {

--- a/src/client.js
+++ b/src/client.js
@@ -143,6 +143,8 @@ const DEFAULTS = {
   sidebarBlur: 16,
   sidebarAlpha: 12,
   sidebarColor: "#ffffff",
+  // Persisted: show the chat-interface mascot pull-cord (rope dock).
+  ropeShown: true,
 };
 
 // Selectable values for the two filters. Declared up top because
@@ -248,6 +250,7 @@ function sanitizeSettings(o) {
     sidebarAlpha: clampNum(o.sidebarAlpha, 0, 60, DEFAULTS.sidebarAlpha),
     sidebarColor: typeof o.sidebarColor === "string" && /^#[0-9a-f]{6}$/i.test(o.sidebarColor)
       ? o.sidebarColor : DEFAULTS.sidebarColor,
+    ropeShown: o.ropeShown !== false,
   };
 }
 
@@ -360,6 +363,7 @@ function serializeSelection() {
     sidebarBlur: selection.sidebarBlur,
     sidebarAlpha: selection.sidebarAlpha,
     sidebarColor: selection.sidebarColor,
+    ropeShown: selection.ropeShown,
   };
 }
 
@@ -1871,6 +1875,11 @@ function WallpaperPicker(props) {
     selection.sidebarColor = hex;
     persistSelection(); emit();
   };
+  // Mascot pull-cord show/hide, persisted with the other toggles.
+  const onRopeVisibilityChange = (e) => {
+    selection.ropeShown = e.target.checked;
+    persistSelection(); emit();
+  };
 
   // Close the picker modal (ESC / backdrop / close buttons share this path).
   const closePicker = () => {
@@ -2116,6 +2125,18 @@ function WallpaperPicker(props) {
         ),
       ),
       ],
+      // Chat-interface mascot (rope dock): show/hide the pull-cord + repo drawer.
+      React.createElement("label", { className: "we-picker__rotation-toggle we-picker__window-toggle" },
+        React.createElement("input", {
+          type: "checkbox",
+          checked: sel.ropeShown !== false,
+          onChange: onRopeVisibilityChange,
+        }),
+        "显示吉祥物（聊天顶部拉绳）",
+      ),
+      React.createElement("span", { className: "we-picker__hint" },
+        "关闭后隐藏吉祥物与壁纸仓库抽屉；可随时在本页重新开启",
+      ),
     ),
     // ── Card-style switch: classic (WE's original aspect-ratio 16/9 cards —
     //    the CD-like look the author liked) vs the rewritten fixed-height
@@ -2914,6 +2935,8 @@ function readRopePos() {
 }
 
 function RopeDock() {
+  const sel = useStore();
+  const hidden = !sel.ropeShown;
   const [open, setOpen] = React.useState(false);
   const [pos, setPos] = React.useState(readRopePos);
   const ropeRef = React.useRef(null);
@@ -3049,15 +3072,25 @@ function RopeDock() {
     return () => window.removeEventListener("resize", onResize);
   }, []);
 
-  // Claim modal ownership ONLY while the panel is open (its picker is mounted).
-  // When closed the picker is unmounted, so the settings copy must own the modal
-  // again — otherwise 选择壁纸 from settings would open nothing. Flipping the
-  // flag triggers emit() so the settings copy re-renders immediately.
+  // Claim modal ownership ONLY while the panel is open AND the rope is visible
+  // (its picker is mounted). When closed or hidden the picker is unmounted, so
+  // the settings copy must own the modal again — otherwise 选择壁纸 from settings
+  // would open nothing. emit() keeps the settings copy in sync; hiding while
+  // open also closes the drawer, so ownership never sticks to an invisible panel.
   React.useEffect(() => {
-    repoPanelOwnsModal = open;
+    if (hidden) setOpen(false);
+    repoPanelOwnsModal = open && !hidden;
     emit();
     return () => { repoPanelOwnsModal = false; emit(); };
-  }, [open]);
+  }, [open, hidden]);
+
+  // Hidden: render nothing (rope + drawer), but keep the one-time update
+  // notice — it is independent of the mascot and must still surface.
+  if (hidden) {
+    return React.createElement(React.Fragment, null,
+      React.createElement(UpdateNotice, null),
+    );
+  }
 
   return React.createElement(React.Fragment, null,
     React.createElement("div", {


### PR DESCRIPTION
## 变更内容

为聊天界面的吉祥物拉绳（RopeDock）新增可持久化的显示开关：默认显示，关闭后拉绳与其壁纸仓库抽屉不再渲染，可在设置页随时重新开启。

## 背景

当前 RopeDock 在 `apply()` 中被无条件挂载：抽屉面板可以收起（点击拉绳 / `收起` 按钮 / ESC），但拉绳本身始终悬浮在聊天区顶部，没有任何隐藏入口。

## 设计

- **持久化字段 `ropeShown`**（默认 `true` = 显示）：语义与 UI 方向一致（勾选 = 显示，取消 = 隐藏），避免"存储隐藏语义 + UI 显示语义"造成的双重否定；经现有 settings 体系持久化（client 端 `DEFAULTS` / `sanitizeSettings` / `serializeSelection` + host 端镜像 → `~/.dsh-wallpaper-engine/config.json`）。
- **开关位置**：设置页「外观」分区，样式与「设置窗口液态玻璃」开关一致（`we-picker__window-toggle`）。仓库抽屉面板托管的是同一个 `WallpaperPicker`，因此开关在设置页与抽屉内均可见，设置页同时作为隐藏后的恢复入口。
- **隐藏行为**：`ropeShown = false` 时 RopeDock 整体不渲染（拉绳 + 抽屉），但保留一次性更新提示（与吉祥物无关，不应随之消失）；抽屉开启时隐藏会自动收起，模态所有权调整为 `open && !hidden`，避免设置页「选择壁纸」模态被残留标志卡死。
- **兼容性**：旧存档缺少该字段时按默认值（显示）处理，白名单自动忽略未知字段，无迁移成本。

## 验证

- `npm run build` 通过（client bundle 与 src 同步、幂等）
- `npm run verify` 全绿：新增 4 条开关断言（存在、默认勾选、取消 / 恢复翻转）+ 既有 client 与 transcode 全套回归

## 已知限制

Wallpaper Engine 未检测到（选择器处于错误 / 扫描状态）时，开关所在的选择器不渲染，需待检测恢复后调整——此时插件本身基本不可用，属可接受边界。
