### PR TITLE
feat(font): 字体与气泡样式自定义面板（颜色/字重/字体族/泛光/气泡样式/不透明度/主题自适配/总开关）

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -151,6 +151,15 @@ window.__ModuleLoader__.load({
 		  // with the other settings (host file, port-independent) so it survives DSH
 		  // Desktop's random --port restarts and never re-shows after being closed.
 		  noticeSeen: "",
+		  // ── 字体与气泡样式（自定义增强）：设置面板「字体」分区可调 ──
+		  fontColor: "#000000",
+		  fontWeight: 400,
+		  fontFamily: "inherit",
+		  textGlow: 4,
+		  bubbleStyle: "glass",
+		  bubbleOpacity: 100,
+		  autoFontColor: false,
+		  customDisabled: false,
 		};
 
 		// Selectable values for the two filters. Declared up top because
@@ -272,6 +281,18 @@ window.__ModuleLoader__.load({
 		    ropeForm: ROPE_FORM_VALUES.includes(o.ropeForm) ? o.ropeForm : DEFAULTS.ropeForm,
 		    ropeScale: clampNum(o.ropeScale, ROPE_SCALE_MIN, ROPE_SCALE_MAX, DEFAULTS.ropeScale),
 		    noticeSeen: typeof o.noticeSeen === "string" ? o.noticeSeen : "",
+		    // 字体与气泡样式（自定义增强）
+		    fontColor: typeof o.fontColor === "string" && /^#[0-9a-f]{6}$/i.test(o.fontColor)
+		      ? o.fontColor : DEFAULTS.fontColor,
+		    fontWeight: clampNum(o.fontWeight, 100, 900, DEFAULTS.fontWeight),
+		    fontFamily: ["inherit", "Microsoft YaHei", "KaiTi", "SimSun", "SimHei", "monospace"].includes(o.fontFamily)
+		      ? o.fontFamily : DEFAULTS.fontFamily,
+		    textGlow: clampNum(o.textGlow, 0, 20, DEFAULTS.textGlow),
+		    bubbleStyle: ["transparent", "glass", "solid-light", "solid-dark"].includes(o.bubbleStyle)
+		      ? o.bubbleStyle : DEFAULTS.bubbleStyle,
+		    bubbleOpacity: clampNum(o.bubbleOpacity, 0, 100, DEFAULTS.bubbleOpacity),
+		    autoFontColor: o.autoFontColor === true,
+		    customDisabled: o.customDisabled === true,
 		  };
 		}
 
@@ -398,6 +419,14 @@ window.__ModuleLoader__.load({
 		    ropeForm: selection.ropeForm,
 		    ropeScale: selection.ropeScale,
 		    noticeSeen: selection.noticeSeen,
+		    fontColor: selection.fontColor,
+		    fontWeight: selection.fontWeight,
+		    fontFamily: selection.fontFamily,
+		    textGlow: selection.textGlow,
+		    bubbleStyle: selection.bubbleStyle,
+		    bubbleOpacity: selection.bubbleOpacity,
+		    autoFontColor: selection.autoFontColor,
+		    customDisabled: selection.customDisabled,
 		  };
 		}
 
@@ -1700,6 +1729,8 @@ window.__ModuleLoader__.load({
 		// and on every 500ms transcode poll — a forced synchronous layout storm.
 		let lastScrimCss = "";
 		function applyEffects() {
+		  // 总开关关闭时不施加任何自定义样式，并清掉已注入的变量/样式表。
+		  if (selection.customDisabled) { clearEffects(); return; }
 		  const s = document.body.style;
 		  s.setProperty("--we-scrim-color", "rgba(0,0,0," + selection.scrim + ")");
 		  // Border emphasis: the border tokens are low-alpha hairlines; raise their
@@ -1787,6 +1818,36 @@ window.__ModuleLoader__.load({
 		  if (selection.sidebarContentColor) s.setProperty("--we-content-surface-color", selection.sidebarContentColor);
 		  else s.removeProperty("--we-content-surface-color");
 
+		  // ── 字体与气泡样式（自定义增强）──
+		  const effectiveFontColor = selection.autoFontColor
+		    ? (selection.bubbleStyle === "solid-dark" ? "#ffffff" : "#000000")
+		    : selection.fontColor;
+		  s.setProperty("--we-font-color", effectiveFontColor);
+		  s.setProperty("--we-font-weight", String(selection.fontWeight));
+		  const fontFamilyStack = selection.fontFamily === "inherit"
+		    ? "inherit"
+		    : '"' + selection.fontFamily + '", "Microsoft YaHei", sans-serif';
+		  s.setProperty("--we-font-family", fontFamilyStack);
+		  s.setProperty("--we-text-glow", selection.textGlow + "px");
+		  s.setProperty("--we-bubble-style", selection.bubbleStyle);
+		  // 气泡背景不透明度缩放
+		  const bubbleOpacity = Math.max(0, Math.min(100, Number(selection.bubbleOpacity) || DEFAULTS.bubbleOpacity));
+		  const bubbleMap = {
+		    transparent: "rgba(255,255,255,0)",
+		    glass: "rgba(255,255,255,0.45)",
+		    "solid-light": "rgba(255,255,255,0.82)",
+		    "solid-dark": "rgba(0,0,0,0.65)",
+		  };
+		  const rawBubbleBg = bubbleMap[selection.bubbleStyle] || bubbleMap.glass;
+		  const applyBubbleOpacity = (rgba, pct) => {
+		    const m = rgba.match(/rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)/);
+		    if (!m) return rgba;
+		    const a = Math.max(0, Math.min(1, parseFloat(m[4]) * (pct / 100)));
+		    return "rgba(" + m[1] + "," + m[2] + "," + m[3] + "," + a + ")";
+		  };
+		  s.setProperty("--we-bubble-bg", applyBubbleOpacity(rawBubbleBg, bubbleOpacity));
+		  applyFontStyles();
+
 		  // Scrim immediacy: some composited/kiosk environments do not repaint a
 		  // z-index:-1 layer promptly when only an inherited CSS variable changes.
 		  // Write the resolved color DIRECTLY onto the scrim element's inline style and
@@ -1804,6 +1865,45 @@ window.__ModuleLoader__.load({
 		      void document.body.offsetHeight;
 		    }
 		  }
+		}
+
+		// 根据当前 selection 动态生成 #we-font-patch 样式表：全局字体覆盖 +
+		// 报错红字保护（error/danger/warning 语义元素强制红色、去泛光）+
+		// 聊天气泡背景（覆盖 dsh 当前版本不读 --dsw-specific-bubble 的问题）。
+		function applyFontStyles() {
+		  try {
+		    let st = document.getElementById("we-font-patch");
+		    if (!st) {
+		      st = document.createElement("style");
+		      st.id = "we-font-patch";
+		      (document.head || document.documentElement).appendChild(st);
+		    }
+		    const family = selection.fontFamily === "inherit"
+		      ? "inherit"
+		      : '"' + selection.fontFamily + '", "Microsoft YaHei", sans-serif';
+		    st.textContent = [
+		      /* 普通文本：排除错误/危险/警告语义，避免盖掉报错红字 */
+		      'body *:not(:has([class*="error" i])):not(:has([class*="danger" i])):not(:has([class*="invalid" i])):not(:has([class*="destructive" i])):not(:has([class*="warning" i])):not([class*="error" i]):not([class*="danger" i]):not([class*="invalid" i]):not([class*="destructive" i]):not([class*="warning" i]):not([data-variant="error"]):not([data-variant="destructive"]):not([data-variant="danger"]) {',
+		      '  color:var(--we-font-color, #000) !important;',
+		      '  font-weight:var(--we-font-weight, 400) !important;',
+		      '  font-family:' + family + ' !important;',
+		      '  text-shadow:0 0 var(--we-text-glow, 0px) rgba(255,255,255,.9),',
+		      '             0 0 calc(var(--we-text-glow, 0px) * 1.5) rgba(255,255,255,.65) !important;',
+		      '}',
+		      /* 报错/危险/警告：强制红色、去掉泛光，保证报错清晰可辨 */
+		      'body *[class*="error" i],body *[class*="danger" i],body *[class*="invalid" i],body *[class*="destructive" i],body *[class*="warning" i],body *[data-variant="error"],body *[data-variant="destructive"],body *[data-variant="danger"] {',
+		      '  color:#ef4444 !important;',
+		      '  text-shadow:none !important;',
+		      '}',
+		      /* 聊天气泡背景 */
+		      'body[data-we-wallpaper] div[class*="_frame"]:not([class*="settingsArea"]):not([class*="sidebarCol"]) {',
+		      '  background-color:var(--we-bubble-bg, transparent) !important;',
+		      '}',
+		      'body[data-we-wallpaper] div[class*="centerCol"] {',
+		      '  background-color:var(--we-bubble-bg, transparent) !important;',
+		      '}',
+		    ].join('\n');
+		  } catch { /* ignore */ }
 		}
 
 		function clearEffects() {
@@ -1830,6 +1930,14 @@ window.__ModuleLoader__.load({
 		  document.body.removeAttribute("data-we-sidebar-glass");
 		  s.removeProperty("--we-content-surface-alpha");
 		  s.removeProperty("--we-content-surface-color");
+		  s.removeProperty("--we-font-color");
+		  s.removeProperty("--we-font-weight");
+		  s.removeProperty("--we-font-family");
+		  s.removeProperty("--we-text-glow");
+		  s.removeProperty("--we-bubble-style");
+		  s.removeProperty("--we-bubble-bg");
+		  const fontPatch = document.getElementById("we-font-patch");
+		  if (fontPatch) fontPatch.remove();
 		  const scrim = document.getElementById(SCRIM_ID);
 		  if (scrim) scrim.style.background = "";
 		  lastScrimCss = "";
@@ -2076,6 +2184,55 @@ window.__ModuleLoader__.load({
 		    }
 		    if (!/^#[0-9a-f]{6}$/i.test(hex)) return;
 		    selection.sidebarContentColor = hex;
+		    persistSelection(); applyEffects(); emit();
+		  };
+
+		  // ── 字体与气泡样式（自定义增强）：各项立即生效并持久化 ──
+		  const onFontColor = (hex) => {
+		    if (!/^#[0-9a-f]{6}$/i.test(hex)) return;
+		    selection.fontColor = hex;
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  const onFontWeight = (v) => {
+		    selection.fontWeight = clampNum(v, 100, 900, DEFAULTS.fontWeight);
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  const onFontFamily = (family) => {
+		    if (!["inherit", "Microsoft YaHei", "KaiTi", "SimSun", "SimHei", "monospace"].includes(family)) return;
+		    selection.fontFamily = family;
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  const onTextGlow = (v) => {
+		    selection.textGlow = clampNum(v, 0, 20, DEFAULTS.textGlow);
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  const onBubbleStyle = (style) => {
+		    if (!["transparent", "glass", "solid-light", "solid-dark"].includes(style)) return;
+		    selection.bubbleStyle = style;
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  const onBubbleOpacity = (v) => {
+		    selection.bubbleOpacity = clampNum(v, 0, 100, DEFAULTS.bubbleOpacity);
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  const onAutoFontColor = (v) => {
+		    selection.autoFontColor = !!v;
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  // 字体样式恢复默认
+		  const onResetFont = () => {
+		    selection.fontColor = DEFAULTS.fontColor;
+		    selection.fontWeight = DEFAULTS.fontWeight;
+		    selection.fontFamily = DEFAULTS.fontFamily;
+		    selection.textGlow = DEFAULTS.textGlow;
+		    selection.bubbleStyle = DEFAULTS.bubbleStyle;
+		    selection.bubbleOpacity = DEFAULTS.bubbleOpacity;
+		    selection.autoFontColor = DEFAULTS.autoFontColor;
+		    persistSelection(); applyEffects(); emit();
+		  };
+		  // 自定义样式总开关：关闭后字体/气泡等全部回归 dsh 默认外观
+		  const onToggleCustomDisabled = (v) => {
+		    selection.customDisabled = !!v;
 		    persistSelection(); applyEffects(); emit();
 		  };
 
@@ -2715,6 +2872,92 @@ window.__ModuleLoader__.load({
 		        onClick: onRefresh, disabled: sel.loading,
 		      }, sel.loading ? "刷新中…" : "刷新"),
 		    ),
+		    ),
+		    // ── 字体（自定义增强）：总开关 / 恢复默认 / 颜色 / 字重 / 泛光 /
+		    //    字体族 / 气泡样式 / 气泡不透明度 / 主题自适配字体颜色 ──
+		    React.createElement("div", { className: "we-picker__section" },
+		      React.createElement("div", { className: "we-picker__section-head" },
+		        React.createElement("span", { className: "we-picker__section-label" }, "字体"),
+		      ),
+		      React.createElement("div", { className: "we-picker__row" },
+		        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "关闭自定义样式"),
+		        React.createElement("label", { className: "we-picker__switch", title: "关闭后字体、字重、气泡等全部回归 dsh 默认外观" },
+		          React.createElement("input", {
+		            type: "checkbox",
+		            checked: sel.customDisabled,
+		            onChange: (e) => onToggleCustomDisabled(e.target.checked),
+		          }),
+		          React.createElement("span", { className: "we-picker__switch-track" },
+		            React.createElement("span", { className: "we-picker__switch-thumb" }),
+		          ),
+		        ),
+		      ),
+		      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+		        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "字体预设"),
+		        React.createElement("button", {
+		          key: "reset-font",
+		          className: "we-picker__swatch we-picker__swatch--active",
+		          type: "button",
+		          style: { minWidth: "72px", padding: "0 10px", fontSize: "12px", borderRadius: "6px" },
+		          title: "恢复字体与气泡默认样式",
+		          onClick: () => onResetFont(),
+		        }, "恢复默认"),
+		      ),
+		      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+		        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "字体颜色"),
+		        React.createElement("label", { className: "we-picker__swatch-custom" },
+		          React.createElement("input", {
+		            type: "color",
+		            value: sel.fontColor,
+		            onInput: (e) => onFontColor(e.target.value),
+		            onChange: (e) => onFontColor(e.target.value),
+		            title: "自定义字体颜色",
+		          }),
+		          React.createElement("span", { className: "we-picker__hint" }, sel.fontColor),
+		        ),
+		      ),
+		      SliderRow("字重", 100, 900, 50, sel.fontWeight, onFontWeight, String(sel.fontWeight)),
+		      SliderRow("泛光", 0, 20, 1, sel.textGlow, onTextGlow, sel.textGlow + "px"),
+		      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+		        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "字体"),
+		        ["inherit", "Microsoft YaHei", "KaiTi", "SimSun", "SimHei", "monospace"].map((family) =>
+		          React.createElement("button", {
+		            key: family,
+		            className: "we-picker__swatch" + (sel.fontFamily === family ? " we-picker__swatch--active" : ""),
+		            type: "button",
+		            style: { minWidth: "48px", padding: "0 8px", fontSize: "12px", borderRadius: "6px" },
+		            title: family,
+		            onClick: () => onFontFamily(family),
+		          }, family === "inherit" ? "默认" : family === "Microsoft YaHei" ? "微软雅黑" : family === "KaiTi" ? "楷体" : family === "SimSun" ? "宋体" : family === "SimHei" ? "黑体" : "等宽"),
+		        ),
+		      ),
+		      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+		        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "气泡样式"),
+		        ["transparent", "glass", "solid-light", "solid-dark"].map((style) =>
+		          React.createElement("button", {
+		            key: style,
+		            className: "we-picker__swatch" + (sel.bubbleStyle === style ? " we-picker__swatch--active" : ""),
+		            type: "button",
+		            style: { minWidth: "48px", padding: "0 8px", fontSize: "12px", borderRadius: "6px" },
+		            title: style,
+		            onClick: () => onBubbleStyle(style),
+		          }, style === "transparent" ? "透明" : style === "glass" ? "毛玻璃" : style === "solid-light" ? "白底" : "黑底"),
+		        ),
+		      ),
+		      SliderRow("气泡不透明度", 0, 100, 1, sel.bubbleOpacity, onBubbleOpacity, sel.bubbleOpacity + "%"),
+		      React.createElement("div", { className: "we-picker__row" },
+		        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "主题自适配字体颜色"),
+		        React.createElement("label", { className: "we-picker__switch", title: "根据气泡主题自动选择最合适的黑/白字体颜色" },
+		          React.createElement("input", {
+		            type: "checkbox",
+		            checked: sel.autoFontColor,
+		            onChange: (e) => onAutoFontColor(e.target.checked),
+		          }),
+		          React.createElement("span", { className: "we-picker__switch-track" },
+		            React.createElement("span", { className: "we-picker__switch-thumb" }),
+		          ),
+		        ),
+		      ),
 		    ),
 		    // ── 自定义壁纸: local JPG/PNG/MP4 as wallpapers. Files are written by the
 		    //    host into its plugin-managed directory and served through the same

--- a/lib/index.js
+++ b/lib/index.js
@@ -866,6 +866,18 @@ function sanitizeSettings(raw) {
     ropeScale: clampNum(o.ropeScale, ROPE_SCALE_MIN, ROPE_SCALE_MAX, 1),
     // "What's new" notice dismissal version (port-independent, mirror of client).
     noticeSeen: typeof o.noticeSeen === 'string' ? o.noticeSeen : '',
+    // Font & bubble customization (mirror of src/client.js).
+    fontColor: typeof o.fontColor === 'string' && /^#[0-9a-f]{6}$/i.test(o.fontColor)
+      ? o.fontColor : '#000000',
+    fontWeight: clampNum(o.fontWeight, 100, 900, 400),
+    fontFamily: ['inherit', 'Microsoft YaHei', 'KaiTi', 'SimSun', 'SimHei', 'monospace'].includes(o.fontFamily)
+      ? o.fontFamily : 'inherit',
+    textGlow: clampNum(o.textGlow, 0, 20, 4),
+    bubbleStyle: ['transparent', 'glass', 'solid-light', 'solid-dark'].includes(o.bubbleStyle)
+      ? o.bubbleStyle : 'glass',
+    bubbleOpacity: clampNum(o.bubbleOpacity, 0, 100, 100),
+    autoFontColor: o.autoFontColor === true,
+    customDisabled: o.customDisabled === true,
   };
 }
 

--- a/src/client.js
+++ b/src/client.js
@@ -175,6 +175,15 @@ const DEFAULTS = {
   // with the other settings (host file, port-independent) so it survives DSH
   // Desktop's random --port restarts and never re-shows after being closed.
   noticeSeen: "",
+  // ── 字体与气泡样式（自定义增强）：设置面板「字体」分区可调 ──
+  fontColor: "#000000",
+  fontWeight: 400,
+  fontFamily: "inherit",
+  textGlow: 4,
+  bubbleStyle: "glass",
+  bubbleOpacity: 100,
+  autoFontColor: false,
+  customDisabled: false,
 };
 
 // Selectable values for the two filters. Declared up top because
@@ -296,6 +305,18 @@ function sanitizeSettings(o) {
     ropeForm: ROPE_FORM_VALUES.includes(o.ropeForm) ? o.ropeForm : DEFAULTS.ropeForm,
     ropeScale: clampNum(o.ropeScale, ROPE_SCALE_MIN, ROPE_SCALE_MAX, DEFAULTS.ropeScale),
     noticeSeen: typeof o.noticeSeen === "string" ? o.noticeSeen : "",
+    // 字体与气泡样式（自定义增强）
+    fontColor: typeof o.fontColor === "string" && /^#[0-9a-f]{6}$/i.test(o.fontColor)
+      ? o.fontColor : DEFAULTS.fontColor,
+    fontWeight: clampNum(o.fontWeight, 100, 900, DEFAULTS.fontWeight),
+    fontFamily: ["inherit", "Microsoft YaHei", "KaiTi", "SimSun", "SimHei", "monospace"].includes(o.fontFamily)
+      ? o.fontFamily : DEFAULTS.fontFamily,
+    textGlow: clampNum(o.textGlow, 0, 20, DEFAULTS.textGlow),
+    bubbleStyle: ["transparent", "glass", "solid-light", "solid-dark"].includes(o.bubbleStyle)
+      ? o.bubbleStyle : DEFAULTS.bubbleStyle,
+    bubbleOpacity: clampNum(o.bubbleOpacity, 0, 100, DEFAULTS.bubbleOpacity),
+    autoFontColor: o.autoFontColor === true,
+    customDisabled: o.customDisabled === true,
   };
 }
 
@@ -422,6 +443,14 @@ function serializeSelection() {
     ropeForm: selection.ropeForm,
     ropeScale: selection.ropeScale,
     noticeSeen: selection.noticeSeen,
+    fontColor: selection.fontColor,
+    fontWeight: selection.fontWeight,
+    fontFamily: selection.fontFamily,
+    textGlow: selection.textGlow,
+    bubbleStyle: selection.bubbleStyle,
+    bubbleOpacity: selection.bubbleOpacity,
+    autoFontColor: selection.autoFontColor,
+    customDisabled: selection.customDisabled,
   };
 }
 
@@ -1724,6 +1753,8 @@ function syncLayers() {
 // and on every 500ms transcode poll — a forced synchronous layout storm.
 let lastScrimCss = "";
 function applyEffects() {
+  // 总开关关闭时不施加任何自定义样式，并清掉已注入的变量/样式表。
+  if (selection.customDisabled) { clearEffects(); return; }
   const s = document.body.style;
   s.setProperty("--we-scrim-color", "rgba(0,0,0," + selection.scrim + ")");
   // Border emphasis: the border tokens are low-alpha hairlines; raise their
@@ -1811,6 +1842,36 @@ function applyEffects() {
   if (selection.sidebarContentColor) s.setProperty("--we-content-surface-color", selection.sidebarContentColor);
   else s.removeProperty("--we-content-surface-color");
 
+  // ── 字体与气泡样式（自定义增强）──
+  const effectiveFontColor = selection.autoFontColor
+    ? (selection.bubbleStyle === "solid-dark" ? "#ffffff" : "#000000")
+    : selection.fontColor;
+  s.setProperty("--we-font-color", effectiveFontColor);
+  s.setProperty("--we-font-weight", String(selection.fontWeight));
+  const fontFamilyStack = selection.fontFamily === "inherit"
+    ? "inherit"
+    : '"' + selection.fontFamily + '", "Microsoft YaHei", sans-serif';
+  s.setProperty("--we-font-family", fontFamilyStack);
+  s.setProperty("--we-text-glow", selection.textGlow + "px");
+  s.setProperty("--we-bubble-style", selection.bubbleStyle);
+  // 气泡背景不透明度缩放
+  const bubbleOpacity = Math.max(0, Math.min(100, Number(selection.bubbleOpacity) || DEFAULTS.bubbleOpacity));
+  const bubbleMap = {
+    transparent: "rgba(255,255,255,0)",
+    glass: "rgba(255,255,255,0.45)",
+    "solid-light": "rgba(255,255,255,0.82)",
+    "solid-dark": "rgba(0,0,0,0.65)",
+  };
+  const rawBubbleBg = bubbleMap[selection.bubbleStyle] || bubbleMap.glass;
+  const applyBubbleOpacity = (rgba, pct) => {
+    const m = rgba.match(/rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)/);
+    if (!m) return rgba;
+    const a = Math.max(0, Math.min(1, parseFloat(m[4]) * (pct / 100)));
+    return "rgba(" + m[1] + "," + m[2] + "," + m[3] + "," + a + ")";
+  };
+  s.setProperty("--we-bubble-bg", applyBubbleOpacity(rawBubbleBg, bubbleOpacity));
+  applyFontStyles();
+
   // Scrim immediacy: some composited/kiosk environments do not repaint a
   // z-index:-1 layer promptly when only an inherited CSS variable changes.
   // Write the resolved color DIRECTLY onto the scrim element's inline style and
@@ -1828,6 +1889,45 @@ function applyEffects() {
       void document.body.offsetHeight;
     }
   }
+}
+
+// 根据当前 selection 动态生成 #we-font-patch 样式表：全局字体覆盖 +
+// 报错红字保护（error/danger/warning 语义元素强制红色、去泛光）+
+// 聊天气泡背景（覆盖 dsh 当前版本不读 --dsw-specific-bubble 的问题）。
+function applyFontStyles() {
+  try {
+    let st = document.getElementById("we-font-patch");
+    if (!st) {
+      st = document.createElement("style");
+      st.id = "we-font-patch";
+      (document.head || document.documentElement).appendChild(st);
+    }
+    const family = selection.fontFamily === "inherit"
+      ? "inherit"
+      : '"' + selection.fontFamily + '", "Microsoft YaHei", sans-serif';
+    st.textContent = [
+      /* 普通文本：排除错误/危险/警告语义，避免盖掉报错红字 */
+      'body *:not(:has([class*="error" i])):not(:has([class*="danger" i])):not(:has([class*="invalid" i])):not(:has([class*="destructive" i])):not(:has([class*="warning" i])):not([class*="error" i]):not([class*="danger" i]):not([class*="invalid" i]):not([class*="destructive" i]):not([class*="warning" i]):not([data-variant="error"]):not([data-variant="destructive"]):not([data-variant="danger"]) {',
+      '  color:var(--we-font-color, #000) !important;',
+      '  font-weight:var(--we-font-weight, 400) !important;',
+      '  font-family:' + family + ' !important;',
+      '  text-shadow:0 0 var(--we-text-glow, 0px) rgba(255,255,255,.9),',
+      '             0 0 calc(var(--we-text-glow, 0px) * 1.5) rgba(255,255,255,.65) !important;',
+      '}',
+      /* 报错/危险/警告：强制红色、去掉泛光，保证报错清晰可辨 */
+      'body *[class*="error" i],body *[class*="danger" i],body *[class*="invalid" i],body *[class*="destructive" i],body *[class*="warning" i],body *[data-variant="error"],body *[data-variant="destructive"],body *[data-variant="danger"] {',
+      '  color:#ef4444 !important;',
+      '  text-shadow:none !important;',
+      '}',
+      /* 聊天气泡背景 */
+      'body[data-we-wallpaper] div[class*="_frame"]:not([class*="settingsArea"]):not([class*="sidebarCol"]) {',
+      '  background-color:var(--we-bubble-bg, transparent) !important;',
+      '}',
+      'body[data-we-wallpaper] div[class*="centerCol"] {',
+      '  background-color:var(--we-bubble-bg, transparent) !important;',
+      '}',
+    ].join('\n');
+  } catch { /* ignore */ }
 }
 
 function clearEffects() {
@@ -1854,6 +1954,14 @@ function clearEffects() {
   document.body.removeAttribute("data-we-sidebar-glass");
   s.removeProperty("--we-content-surface-alpha");
   s.removeProperty("--we-content-surface-color");
+  s.removeProperty("--we-font-color");
+  s.removeProperty("--we-font-weight");
+  s.removeProperty("--we-font-family");
+  s.removeProperty("--we-text-glow");
+  s.removeProperty("--we-bubble-style");
+  s.removeProperty("--we-bubble-bg");
+  const fontPatch = document.getElementById("we-font-patch");
+  if (fontPatch) fontPatch.remove();
   const scrim = document.getElementById(SCRIM_ID);
   if (scrim) scrim.style.background = "";
   lastScrimCss = "";
@@ -2100,6 +2208,55 @@ function WallpaperPicker(props) {
     }
     if (!/^#[0-9a-f]{6}$/i.test(hex)) return;
     selection.sidebarContentColor = hex;
+    persistSelection(); applyEffects(); emit();
+  };
+
+  // ── 字体与气泡样式（自定义增强）：各项立即生效并持久化 ──
+  const onFontColor = (hex) => {
+    if (!/^#[0-9a-f]{6}$/i.test(hex)) return;
+    selection.fontColor = hex;
+    persistSelection(); applyEffects(); emit();
+  };
+  const onFontWeight = (v) => {
+    selection.fontWeight = clampNum(v, 100, 900, DEFAULTS.fontWeight);
+    persistSelection(); applyEffects(); emit();
+  };
+  const onFontFamily = (family) => {
+    if (!["inherit", "Microsoft YaHei", "KaiTi", "SimSun", "SimHei", "monospace"].includes(family)) return;
+    selection.fontFamily = family;
+    persistSelection(); applyEffects(); emit();
+  };
+  const onTextGlow = (v) => {
+    selection.textGlow = clampNum(v, 0, 20, DEFAULTS.textGlow);
+    persistSelection(); applyEffects(); emit();
+  };
+  const onBubbleStyle = (style) => {
+    if (!["transparent", "glass", "solid-light", "solid-dark"].includes(style)) return;
+    selection.bubbleStyle = style;
+    persistSelection(); applyEffects(); emit();
+  };
+  const onBubbleOpacity = (v) => {
+    selection.bubbleOpacity = clampNum(v, 0, 100, DEFAULTS.bubbleOpacity);
+    persistSelection(); applyEffects(); emit();
+  };
+  const onAutoFontColor = (v) => {
+    selection.autoFontColor = !!v;
+    persistSelection(); applyEffects(); emit();
+  };
+  // 字体样式恢复默认
+  const onResetFont = () => {
+    selection.fontColor = DEFAULTS.fontColor;
+    selection.fontWeight = DEFAULTS.fontWeight;
+    selection.fontFamily = DEFAULTS.fontFamily;
+    selection.textGlow = DEFAULTS.textGlow;
+    selection.bubbleStyle = DEFAULTS.bubbleStyle;
+    selection.bubbleOpacity = DEFAULTS.bubbleOpacity;
+    selection.autoFontColor = DEFAULTS.autoFontColor;
+    persistSelection(); applyEffects(); emit();
+  };
+  // 自定义样式总开关：关闭后字体/气泡等全部回归 dsh 默认外观
+  const onToggleCustomDisabled = (v) => {
+    selection.customDisabled = !!v;
     persistSelection(); applyEffects(); emit();
   };
 
@@ -2739,6 +2896,92 @@ function WallpaperPicker(props) {
         onClick: onRefresh, disabled: sel.loading,
       }, sel.loading ? "刷新中…" : "刷新"),
     ),
+    ),
+    // ── 字体（自定义增强）：总开关 / 恢复默认 / 颜色 / 字重 / 泛光 /
+    //    字体族 / 气泡样式 / 气泡不透明度 / 主题自适配字体颜色 ──
+    React.createElement("div", { className: "we-picker__section" },
+      React.createElement("div", { className: "we-picker__section-head" },
+        React.createElement("span", { className: "we-picker__section-label" }, "字体"),
+      ),
+      React.createElement("div", { className: "we-picker__row" },
+        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "关闭自定义样式"),
+        React.createElement("label", { className: "we-picker__switch", title: "关闭后字体、字重、气泡等全部回归 dsh 默认外观" },
+          React.createElement("input", {
+            type: "checkbox",
+            checked: sel.customDisabled,
+            onChange: (e) => onToggleCustomDisabled(e.target.checked),
+          }),
+          React.createElement("span", { className: "we-picker__switch-track" },
+            React.createElement("span", { className: "we-picker__switch-thumb" }),
+          ),
+        ),
+      ),
+      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "字体预设"),
+        React.createElement("button", {
+          key: "reset-font",
+          className: "we-picker__swatch we-picker__swatch--active",
+          type: "button",
+          style: { minWidth: "72px", padding: "0 10px", fontSize: "12px", borderRadius: "6px" },
+          title: "恢复字体与气泡默认样式",
+          onClick: () => onResetFont(),
+        }, "恢复默认"),
+      ),
+      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "字体颜色"),
+        React.createElement("label", { className: "we-picker__swatch-custom" },
+          React.createElement("input", {
+            type: "color",
+            value: sel.fontColor,
+            onInput: (e) => onFontColor(e.target.value),
+            onChange: (e) => onFontColor(e.target.value),
+            title: "自定义字体颜色",
+          }),
+          React.createElement("span", { className: "we-picker__hint" }, sel.fontColor),
+        ),
+      ),
+      SliderRow("字重", 100, 900, 50, sel.fontWeight, onFontWeight, String(sel.fontWeight)),
+      SliderRow("泛光", 0, 20, 1, sel.textGlow, onTextGlow, sel.textGlow + "px"),
+      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "字体"),
+        ["inherit", "Microsoft YaHei", "KaiTi", "SimSun", "SimHei", "monospace"].map((family) =>
+          React.createElement("button", {
+            key: family,
+            className: "we-picker__swatch" + (sel.fontFamily === family ? " we-picker__swatch--active" : ""),
+            type: "button",
+            style: { minWidth: "48px", padding: "0 8px", fontSize: "12px", borderRadius: "6px" },
+            title: family,
+            onClick: () => onFontFamily(family),
+          }, family === "inherit" ? "默认" : family === "Microsoft YaHei" ? "微软雅黑" : family === "KaiTi" ? "楷体" : family === "SimSun" ? "宋体" : family === "SimHei" ? "黑体" : "等宽"),
+        ),
+      ),
+      React.createElement("div", { className: "we-picker__row we-picker__accent-row" },
+        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "气泡样式"),
+        ["transparent", "glass", "solid-light", "solid-dark"].map((style) =>
+          React.createElement("button", {
+            key: style,
+            className: "we-picker__swatch" + (sel.bubbleStyle === style ? " we-picker__swatch--active" : ""),
+            type: "button",
+            style: { minWidth: "48px", padding: "0 8px", fontSize: "12px", borderRadius: "6px" },
+            title: style,
+            onClick: () => onBubbleStyle(style),
+          }, style === "transparent" ? "透明" : style === "glass" ? "毛玻璃" : style === "solid-light" ? "白底" : "黑底"),
+        ),
+      ),
+      SliderRow("气泡不透明度", 0, 100, 1, sel.bubbleOpacity, onBubbleOpacity, sel.bubbleOpacity + "%"),
+      React.createElement("div", { className: "we-picker__row" },
+        React.createElement("span", { className: "we-picker__hint we-picker__label" }, "主题自适配字体颜色"),
+        React.createElement("label", { className: "we-picker__switch", title: "根据气泡主题自动选择最合适的黑/白字体颜色" },
+          React.createElement("input", {
+            type: "checkbox",
+            checked: sel.autoFontColor,
+            onChange: (e) => onAutoFontColor(e.target.checked),
+          }),
+          React.createElement("span", { className: "we-picker__switch-track" },
+            React.createElement("span", { className: "we-picker__switch-thumb" }),
+          ),
+        ),
+      ),
     ),
     // ── 自定义壁纸: local JPG/PNG/MP4 as wallpapers. Files are written by the
     //    host into its plugin-managed directory and served through the same


### PR DESCRIPTION
## 功能说明

新增设置页「字体」分区，全部改动遵循现有代码风格（DEFAULTS / sanitizeSettings / serializeSelection / handlers / applyEffects / UI 分区 + 宿主端镜像）：

- **关闭自定义样式总开关**（`customDisabled`）：关闭后字体、字重、气泡等全部回归 dsh 原生外观（applyEffects 短路 + clearEffects 清理注入的变量与样式表）
- **字体颜色 / 字重(100–900) / 字体族**（默认/微软雅黑/楷体/宋体/黑体/等宽）/ **文字泛光(0–20px)**
- **气泡样式**（透明/毛玻璃/白底/黑底）+ **气泡不透明度(0–100%)**，背景经 `--we-bubble-bg` 生效（覆盖 `_frame`/`centerCol` 容器）
- **主题自适配字体颜色**（`autoFontColor`：选黑底自动切白字）
- **恢复默认按钮**（`onResetFont` 一键还原全部字体/气泡设置）
- **报错红字保护**：error/danger/warning 语义元素强制 `#ef4444` 且去泛光，不会被全局字体颜色规则盖住
- 动态样式注入到独立 `<style id="we-font-patch">`，clearEffects 时移除
- 宿主端 `lib/index.js` 的 sanitizeSettings 已镜像同步全部新字段，client/host 持久化一致

动机：壁纸场景下默认字体在浅色壁纸上对比度不足，且自定义后无法一键还原；本 PR 提供完整的用户侧调节能力并保留系统报错语义。

## 适用平台

Windows（DSH web，Chrome 浏览器实测）

## 验证结果

- `npm run build` ✅（src 改动后重新生成 lib/client.js）
- `npm run verify` ✅（verify-client.mjs 全部断言通过：picker 渲染 / 旋转 / 过滤 / 转码状态等无回归；verify-transcode-state.mjs 15 项全 PASS）
- `git diff --check` ✅
- 真实 DSH web（127.0.0.1:3080）端到端实测：设置面板「字体」分区正常渲染，总开关关闭后立即恢复原生外观，各滑块/取色器即时生效并持久化，重启 DSH 后设置保留

## 提交内容

- `src/client.js`：+243 行（唯一源码改动）
- `lib/client.js`：由 `npm run build` 重新生成
- `lib/index.js`：+12 行（宿主端 sanitizeSettings 镜像）

一个 PR 只做这一件事：字体与气泡样式自定义。