### PR TITLE
fix(uploads): honor .meta.json contentrating for custom wallpapers

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -335,10 +335,11 @@ Above the thumbnail grid in the picker modal there are two dropdowns that
 reproduce Wallpaper Engine's own categorisation:
 
 - **内容分级** (content rating) — reads each wallpaper's `contentrating` field
-  from `project.json` (WE's workshop tags G / PG13 / R): **全部** (all) /
+  (WE wallpapers: `project.json`; custom uploads: `uploads/.meta.json`; the
+  field mirrors WE's workshop tags G / PG13 / R): **全部** (all) /
   **Everyone (G, default)** / **PG13** (parental guidance) / **Mature (R)** /
-  **未分级** (unrated — wallpapers without the field, typically local projects
-  or custom uploads).
+  **未分级** (unrated — wallpapers without the field, typically local projects;
+  custom uploads without a rating stay in this bucket too).
 - **类型** (type) — filters by the embeddable type: **全部** (all) / **视频**
   (video) / **网页** (web) / **图片** (image, custom uploads).
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ dsh plugin --profile web add dsh-plugin-wallpaper-engine
 
 选择壁纸弹窗的网格上方有两个下拉框，复刻 Wallpaper Engine 自己的分类方式：
 
-- **内容分级** —— 读取每张壁纸 `project.json` 的 `contentrating` 字段（即 WE workshop 的 G / PG13 / R 三档标签）：**全部** / **Everyone（G，默认）** / **PG13（家长指导级）** / **Mature（R）** / **未分级**（没有该字段的壁纸，通常是本地项目或自上传内容）。
+- **内容分级** —— 读取每张壁纸的 `contentrating` 字段（WE 壁纸读 `project.json`，自上传内容读 `uploads/.meta.json`，即 WE workshop 的 G / PG13 / R 三档标签）：**全部** / **Everyone（G，默认）** / **PG13（家长指导级）** / **Mature（R）** / **未分级**（没有该字段的壁纸，通常是本地项目；自上传内容未设置时同样按未分级处理）。
 - **类型** —— 按可内嵌类型筛选：**全部** / **视频** / **网页** / **图片**（自上传）。
 
 每个选项都带当前可播放壁纸数量；被过滤的壁纸会从网格、轮播编辑器和轮播候选中整体剔除，也不会被自动选中或轮换。选择保存在浏览器 `localStorage`；默认 Everyone 对应 WE 保守的首启立场。

--- a/lib/index.js
+++ b/lib/index.js
@@ -1621,12 +1621,18 @@ function readUploadMeta() {
  */
 function metaEntry(meta, id) {
   const v = meta[id];
-  if (typeof v === 'string') return { title: v, sha256: null };
+  if (typeof v === 'string') return { title: v, sha256: null, contentrating: null };
   if (v && typeof v === 'object') return {
     title: typeof v.title === 'string' && v.title.trim() ? v.title : id,
     sha256: typeof v.sha256 === 'string' ? v.sha256 : null,
+    // Same field the Workshop path reads from project.json, mirrored for
+    // custom uploads in uploads/.meta.json (WE's G / PG13 / R tags). Missing
+    // or non-string values stay null, so the client keeps showing "unrated"
+    // exactly like before this field existed.
+    contentrating: typeof v.contentrating === 'string' && v.contentrating.trim()
+      ? v.contentrating.trim() : null,
   };
-  return { title: id, sha256: null };
+  return { title: id, sha256: null, contentrating: null };
 }
 
 function setUploadMeta(id, title, sha256) {
@@ -1866,14 +1872,18 @@ export function apply(ctx) {
     // the client-side "无预览" placeholder.
     const uploadsDir = ensureUploadDir();
     const uploadMeta = readUploadMeta();
-    const uploads = (await enumerateUploadsP(uploadsDir)).map((w) => ({
-      id: w.id,
-      title: metaEntry(uploadMeta, w.id).title || w.id,
-      type: w.type,
-      playable: true,
-      media: `${BASE}/media/${tokenFor(w.fileAbs)}`,
-      preview: w.previewAbs ? `${BASE}/preview/${tokenFor(w.previewAbs)}` : null,
-    }));
+    const uploads = (await enumerateUploadsP(uploadsDir)).map((w) => {
+      const me = metaEntry(uploadMeta, w.id);
+      return {
+        id: w.id,
+        title: me.title || w.id,
+        contentrating: me.contentrating,
+        type: w.type,
+        playable: true,
+        media: `${BASE}/media/${tokenFor(w.fileAbs)}`,
+        preview: w.previewAbs ? `${BASE}/preview/${tokenFor(w.previewAbs)}` : null,
+      };
+    });
     wallpapers.push(...uploads);
     const playableIds = new Set(wallpapers.filter((w) => w.playable).map((w) => w.id));
     const playlists = (await readPlaylistsP(installDir)).map((playlist) => {


### PR DESCRIPTION
# PR: fix(uploads): honor .meta.json contentrating for custom wallpapers

- Target branch: `main`
- Local branch: `fix/upload-contentrating`
- Local commit: `2b7ced7`
- Patch: `pr-1-contentrating.patch`
- Files: `lib/index.js`, `README.md`, `README.en.md`

## Problem

The content-rating filter added in #15 reads each wallpaper's `contentrating`
field, but custom uploads never expose it:

- `metaEntry()` (`lib/index.js`) reads only `title` / `sha256` from
  `uploads/.meta.json`.
- The uploads branch of `buildInventory()` therefore never emits
  `contentrating` for uploaded wallpapers.

Result: every custom upload is classified as **未分级 / unrated**, even when its
`.meta.json` entry already carries a WE rating (`Everyone` / `PG13` / `Mature`).
The README already documents this limitation ("typically local projects or
custom uploads").

## Fix

- `metaEntry()` normalizes `contentrating` (trimmed string, else `null`).
- The uploads branch of `buildInventory()` passes it through, exactly like the
  Workshop branch already does for `project.json`.
- README (both languages): the field is read from `project.json` for WE
  wallpapers and from `uploads/.meta.json` for custom uploads.

No client change is needed — the filter already handles the field and treats
missing / `null` as unrated.

## Compatibility

- Existing uploads without the field behave exactly as before (`null` →
  unrated).
- Non-string values are ignored (`null`).
- Legacy string-form `.meta.json` entries (`{ "<id>": "title" }`) keep working.

## Verification

- `npm run verify` — green (client + transcode-state checks all pass).
- Local harness driving the real `apply()` + the real inventory route, with four
  fixtures:
  - `PG13` → passes through as `"PG13"`
  - missing field → `null`
  - legacy string-form entry → title preserved, `null` rating
  - non-string value (`123`) → `null`
- No new dependencies, no new routes, no client rebuild.

## Follow-up

There is still no UI/API to *set* the rating; this PR makes the host honor the
field that the upload metadata already supports. A user-facing setter (and a
custom preview setter) is proposed separately — see the issue draft
#76.

---

## 中文摘要

内容分级过滤器（#15）会读取壁纸的 `contentrating`，但自定义上传走的是
`metaEntry()`，只读取 `title` / `sha256`，inventory 也从不输出该字段，导致
所有自上传壁纸恒为「未分级」。本 PR 让 `metaEntry()` 归一化该字段、inventory
透传，与 WE 壁纸读 `project.json` 的行为对齐；缺失/非字符串仍为 `null`
（未分级），老数据与旧字符串形态完全兼容。已验证：仓库 `npm run verify`
全绿；本地 harness 驱动真实 `apply()` + inventory 路由，4 组 fixture
（PG13 / 缺失 / 旧字符串 / 非字符串）全部通过。
